### PR TITLE
Object class

### DIFF
--- a/include/CLE.h
+++ b/include/CLE.h
@@ -77,7 +77,7 @@ Image<T> CLE::Pull(Buffer& gpu_obj)
     unsigned int arrSize = gpu_obj.GetDimensions()[0] * gpu_obj.GetDimensions()[1] * gpu_obj.GetDimensions()[2];
     size_t bitSize = sizeof(T) * arrSize;
     T* output_arr = new T[arrSize];
-    cl_int clError = clEnqueueReadBuffer(gpu.GetCommandQueue(), gpu_obj.GetPointer(), CL_TRUE, 0, bitSize, output_arr, 0, NULL, NULL);
+    cl_int clError = clEnqueueReadBuffer(gpu.GetCommandQueue(), gpu_obj.GetData(), CL_TRUE, 0, bitSize, output_arr, 0, NULL, NULL);
     if (clError != CL_SUCCESS)
     {
         std::cerr << "Pull error! fail to read buffer : " << getOpenCLErrorString(clError) << std::endl;

--- a/include/CLE.h
+++ b/include/CLE.h
@@ -12,8 +12,9 @@
 #define __CLE_h
 
 
+
 #include "cleGPU.h"
-#include "cleBuffer.h"
+#include "cleObject.h"
 #include "image.h"
 
 
@@ -82,7 +83,7 @@ Image<T> CLE::Pull(Buffer& gpu_obj)
         std::cerr << "Pull error! fail to read buffer : " << getOpenCLErrorString(clError) << std::endl;
         throw clError;
     }
-    Image<T> image (output_arr, gpu_obj.GetDimensions()[0], gpu_obj.GetDimensions()[1], gpu_obj.GetDimensions()[2], gpu_obj.GetType());
+    Image<T> image (output_arr, gpu_obj.GetDimensions()[0], gpu_obj.GetDimensions()[1], gpu_obj.GetDimensions()[2], gpu_obj.GetDataType());
     return image;        
 }
 
@@ -116,7 +117,7 @@ Buffer CLE::Create(Buffer& gpu_obj, std::string type)
     }
     if (type.empty())
     {
-        type = gpu_obj.GetType();
+        type = gpu_obj.GetDataType();
     }
     return Buffer (mem_obj, gpu_obj.GetDimensions().data(), type);
 }

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -7,7 +7,9 @@ set(HEADERS
     ${header_path}/cleKernelList.h
     ${header_path}/cleGPU.h
     ${header_path}/cleKernel.h
+    ${header_path}/cleObject.h
     ${header_path}/cleBuffer.h
+    ${header_path}/cleScalar.h
     ${header_path}/cleAddImageAndScalarKernel.h
     ${header_path}/cleSmallerOrEqualConstantKernel.h
     ${header_path}/cleMaximumZProjectionKernel.h

--- a/include/cleBuffer.h
+++ b/include/cleBuffer.h
@@ -33,7 +33,7 @@ public:
     Buffer(cl_mem, unsigned int [3], std::string);
     ~Buffer();
 
-    cl_mem GetPointer();
+    cl_mem& GetData();
     std::array<unsigned int, 3> GetDimensions();
 
     std::string GetObjectType() const;

--- a/include/cleKernel.h
+++ b/include/cleKernel.h
@@ -22,6 +22,7 @@
 #include <iostream>
 #include <map>
 
+#include "cleObject.h"
 #include "cleBuffer.h"
 #include "cleGPU.h"
 
@@ -47,6 +48,7 @@ protected:
     std::string kernelName;
     std::map<std::string, Buffer> parameters;
 
+    std::string TypeAbbr(const std::string) const;
     std::string LoadPreamble();
     std::string LoadSources();
     std::string LoadDefines();

--- a/include/cleObject.h
+++ b/include/cleObject.h
@@ -1,0 +1,48 @@
+/*  CLIc - version 0.1 - Copyright 2020 Stéphane Rigaud, Robert Haase,
+*   Institut Pasteur Paris, Max Planck Institute for Molecular Cell Biology and Genetics Dresden
+*
+*   CLIc is part of the clEsperanto project http://clesperanto.net 
+*
+*   This file is subject to the terms and conditions defined in
+*   file 'LICENSE.txt', which is part of this source code package.
+*/
+
+
+#ifndef __cleObject_h
+#define __cleObject_h
+
+#ifdef __APPLE__
+#include <OpenCL/opencl.h>
+#else
+#include <CL/cl.h>
+#endif
+
+#include <string>
+#include <fstream>
+
+namespace cle
+{
+
+class Object
+{
+public:
+    enum ObjectType {Scalar, Buffer, Image2d};
+    enum DataType {Float, Char, UChar, Int, UInt, Short, UShort};
+
+protected:
+    std::string DataTypeToString(const DataType) const;
+    std::string ObjectTypeToString(const ObjectType) const;
+    DataType StringToDataType(const std::string) const;
+    friend std::ostream & operator<<(std::ostream &, const Object&);
+
+public:
+    Object(){};
+    ~Object(){};
+
+    virtual std::string GetObjectType() const = 0;
+    virtual std::string ToString() const = 0;
+};
+
+} // namespace cle
+
+#endif // __cleObject_h

--- a/include/cleScalar.h
+++ b/include/cleScalar.h
@@ -8,8 +8,8 @@
 */
 
 
-#ifndef __cleBuffer_h
-#define __cleBuffer_h
+#ifndef __cleScalar_h
+#define __cleScalar_h
 
 #include "cleObject.h"
 
@@ -18,23 +18,18 @@
 namespace cle
 {
     
-class Buffer : public Object
+class Scalar : public Object
 {
 
 private:
-    static const ObjectType O = ObjectType::Buffer;
-
-    DataType T;
-    cl_mem pointer = nullptr;
-    std::array<unsigned int, 3> dimensions = {0, 0, 0};
+    static const ObjectType O = ObjectType::Scalar;
+    static const DataType T = DataType::Float;
+    float value;
     
-public:      
-    Buffer(){};
-    Buffer(cl_mem, unsigned int [3], std::string);
-    ~Buffer();
-
-    cl_mem GetPointer();
-    std::array<unsigned int, 3> GetDimensions();
+public:        
+    Scalar(float);
+    ~Scalar();
+    float GetValue();
 
     std::string GetObjectType() const;
     std::string GetDataType() const;
@@ -45,4 +40,4 @@ public:
 
 } // namespace cle
 
-#endif // __cleBuffer_h
+#endif // __cleScalar_h

--- a/include/cleScalar.h
+++ b/include/cleScalar.h
@@ -29,7 +29,7 @@ private:
 public:        
     Scalar(float);
     ~Scalar();
-    float GetValue();
+    float& GetData();
 
     std::string GetObjectType() const;
     std::string GetDataType() const;

--- a/include/image.h
+++ b/include/image.h
@@ -27,7 +27,7 @@ private:
 public:
     Image(){};
     Image(T*, unsigned int=1, unsigned int=1, unsigned int=1, std::string ="float");
-    Image(T*, unsigned int*, std::string="float");
+    Image(T*, unsigned int*, std::string ="float");
     ~Image();
 
     void SetKey(std::string);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,13 +5,15 @@ set(source_path ${CMAKE_CURRENT_SOURCE_DIR})
 set(SOURCES
 	${source_path}/CLE.cpp
 	${source_path}/cleGPU.cpp
+	${source_path}/cleObject.cpp
+	${source_path}/cleBuffer.cpp
+	${source_path}/cleScalar.cpp
 	${source_path}/cleKernel.cpp
 	${source_path}/cleAddImageAndScalarKernel.cpp
 	${source_path}/cleSmallerOrEqualConstantKernel.cpp
 	${source_path}/cleMaximumZProjectionKernel.cpp
 	${source_path}/cleMean2DSphereKernel.cpp
 	${source_path}/cleAbsoluteKernel.cpp
-	${source_path}/cleBuffer.cpp
 	${source_path}/tiffreader.cpp
 	${source_path}/tiffwriter.cpp
 	${source_path}/utils.cpp

--- a/src/cleAbsoluteKernel.cpp
+++ b/src/cleAbsoluteKernel.cpp
@@ -26,15 +26,13 @@ void AbsoluteKernel::Execute(Buffer& in, Buffer& out)
 
     // Set the arguments of the kernel
     cl_int clError;
-    cl_mem src_mem = in.GetPointer();
-    cl_mem dst_mem = out.GetPointer();
-    clError = clSetKernelArg(this->GetKernel(), 0, sizeof(cl_mem), &src_mem);
+    clError = clSetKernelArg(this->GetKernel(), 0, sizeof(in.GetData()), &(in.GetData()));
     if (clError != CL_SUCCESS)
     {
         std::cerr << "Argument error! Fail to set argument : " << getOpenCLErrorString(clError) << std::endl;
         throw clError;
     }
-    clError = clSetKernelArg(this->GetKernel(), 1, sizeof(cl_mem), &dst_mem);
+    clError = clSetKernelArg(this->GetKernel(), 1, sizeof(out.GetData()), &(out.GetData()));
     if (clError != CL_SUCCESS)
     {
         std::cerr << "Argument error! Fail to set argument : " << getOpenCLErrorString(clError) << std::endl;

--- a/src/cleAddImageAndScalarKernel.cpp
+++ b/src/cleAddImageAndScalarKernel.cpp
@@ -26,21 +26,19 @@ void AddImageAndScalarKernel::Execute(Buffer& in, Buffer& out, float scalar)
 
     // Set the arguments of the kernel
     cl_int clError;
-    cl_mem src_mem = in.GetPointer();
-    cl_mem dst_mem = out.GetPointer();
-    clError = clSetKernelArg(this->GetKernel(), 0, sizeof(cl_mem), &src_mem);
+    clError = clSetKernelArg(this->GetKernel(), 0, sizeof(in.GetData()), &(in.GetData()));
     if (clError != CL_SUCCESS)
     {
         std::cerr << "Argument error! Fail to set argument : " << getOpenCLErrorString(clError) << std::endl;
         throw clError;
     }
-    clError = clSetKernelArg(this->GetKernel(), 1, sizeof(cl_mem), &dst_mem);
+    clError = clSetKernelArg(this->GetKernel(), 1, sizeof(out.GetData()), &(out.GetData()));
     if (clError != CL_SUCCESS)
     {
         std::cerr << "Argument error! Fail to set argument : " << getOpenCLErrorString(clError) << std::endl;
         throw clError;
     }
-    clError = clSetKernelArg(this->GetKernel(), 2, sizeof(float), (void *)&scalar);
+    clError = clSetKernelArg(this->GetKernel(), 2, sizeof(float), &scalar);
     if (clError != CL_SUCCESS)
     {
         std::cerr << "Argument error! Fail to set argument : " << getOpenCLErrorString(clError) << std::endl;

--- a/src/cleBuffer.cpp
+++ b/src/cleBuffer.cpp
@@ -10,32 +10,23 @@
 
 #include "cleBuffer.h"
 #include <iostream>
+#include <algorithm>
 
 namespace cle
 {
 
-// Buffer::Buffer()
-// {
-//     // pointer = nullptr;
-//     // dimensions = {0, 0, 0};
-//     // type = "";
-//     // typeId = "";
-// }  
-
 Buffer::Buffer(cl_mem _ptr, unsigned int* _dimensions, std::string _type)
 {
     pointer = _ptr;
-    type = _type;
-    typeId = this->TypeId(_type);
+    T = this->StringToDataType(_type);
     int arrSize = sizeof(_dimensions)/sizeof(_dimensions[0]) +1;
     if (arrSize > 3)
     {
-        arrSize = 3;
-        std::cerr << "warning: Buffer maximum dimensions exeeded,"; 
-        std::cerr << "only the three first values are considered.";
+        std::cerr << "Warning: 3 Dimensions maximum, "; 
+        std::cerr << "additional dimensions are ignored.";
         std::cerr << std::endl;
     }
-    for (size_t i = 0; i < arrSize; i++)
+    for (size_t i = 0; i < std::min(arrSize, 3); i++)
     {
         dimensions[i] = _dimensions[i];
     }    
@@ -50,64 +41,59 @@ std::array<unsigned int, 3> Buffer::GetDimensions()
     return dimensions;
 }
 
-std::string Buffer::GetType()
-{
-    return type;
-}
-
-std::string Buffer::GetTypeId()
-{
-    return typeId;
-}
-
 cl_mem Buffer::GetPointer()
 {
     return pointer;
 }
 
-std::string Buffer::TypeId(std::string type)
+// std::string Buffer::TypeId(std::string type)
+// {
+//     std::string res;
+//     if (type.compare("float") == 0)
+//     {
+//         res = "f";
+//     }
+//     else if (type.compare("char") == 0)
+//     {
+//         res =  "c";
+//     }
+//     else if (type.compare("uchar") == 0)
+//     {
+//         res =  "uc";
+//     }
+//     else if (type.compare("int") == 0)
+//     {
+//         res =  "i";
+//     }
+//     else if (type.compare("uint") == 0)
+//     {
+//         res =  "ui";
+//     }
+//     else
+//     {
+//         res = "f";
+//     }
+//     return res; 
+// }
+
+std::string Buffer::GetObjectType() const
 {
-    std::string res;
-    if (type.compare("float") == 0)
-    {
-        res = "f";
-    }
-    else if (type.compare("char") == 0)
-    {
-        res =  "c";
-    }
-    else if (type.compare("uchar") == 0)
-    {
-        res =  "uc";
-    }
-    else if (type.compare("int") == 0)
-    {
-        res =  "i";
-    }
-    else if (type.compare("uint") == 0)
-    {
-        res =  "ui";
-    }
-    else
-    {
-        res = "f";
-    }
-    return res; 
+    return this->ObjectTypeToString(O);
 }
 
-std::string Buffer::to_str() const
+std::string Buffer::GetDataType() const
 {
-    std::string typ = ", dtype=" + typeId + "(" + type + ")";
-    std::string dim = "size=[" + std::to_string(dimensions[0]) + "," 
-                               + std::to_string(dimensions[1]) + "," 
-                               + std::to_string(dimensions[2]) + "]"; 
-    return "clBuffer<" + dim + typ + ">";
-
+    return this->DataTypeToString(T);
 }
 
-std::ostream& operator<<(std::ostream& os, const Buffer& p)
+std::string Buffer::ToString() const
 {
-    return os << p.to_str();
+    // std::string typ = ", dtype=" + typeId + "(" + type + ")";
+    // std::string dim = "size=[" + std::to_string(dimensions[0]) + "," 
+    //                            + std::to_string(dimensions[1]) + "," 
+    //                            + std::to_string(dimensions[2]) + "]"; 
+    // return "clBuffer<" + dim + typ + ">";
+    return "";
 }
 
 } // namespace cle

--- a/src/cleBuffer.cpp
+++ b/src/cleBuffer.cpp
@@ -41,7 +41,7 @@ std::array<unsigned int, 3> Buffer::GetDimensions()
     return dimensions;
 }
 
-cl_mem Buffer::GetPointer()
+cl_mem& Buffer::GetData()
 {
     return pointer;
 }

--- a/src/cleKernel.cpp
+++ b/src/cleKernel.cpp
@@ -64,10 +64,14 @@ std::string Kernel::LoadDefines()
 
     for (auto itr = parameters.begin(); itr != parameters.end(); ++itr)
     {
+        std::string objectType = itr->second.GetObjectType();
+        std::string dataType = itr->second.GetDataType();
+        std::string abbrType = TypeAbbr(dataType);
+
         // image type handling
-        defines = defines + "\n#define CONVERT_" + itr->first + "_PIXEL_TYPE clij_convert_" + itr->second.GetType() + "_sat";
-        defines = defines + "\n#define IMAGE_" + itr->first + "_TYPE __global " + itr->second.GetType() + "*";
-        defines = defines + "\n#define IMAGE_" + itr->first + "_PIXEL_TYPE " + itr->second.GetType();
+        defines = defines + "\n#define CONVERT_" + itr->first + "_PIXEL_TYPE clij_convert_" + dataType + "_sat";
+        defines = defines + "\n#define IMAGE_" + itr->first + "_TYPE __global " + dataType + "*";
+        defines = defines + "\n#define IMAGE_" + itr->first + "_PIXEL_TYPE " + dataType;
 
         // image size handling
         if (itr->second.GetDimensions()[2] > 1)
@@ -113,9 +117,9 @@ std::string Kernel::LoadDefines()
 
         // read/write images
         std::string sdim = (itr->second.GetDimensions()[2] == 1) ? "2" : "3";
-        defines = defines + "\n#define READ_" + itr->first + "_IMAGE(a,b,c) read_buffer" + sdim + "d" + itr->second.GetTypeId() +
+        defines = defines + "\n#define READ_" + itr->first + "_IMAGE(a,b,c) read_buffer" + sdim + "d" + abbrType +
                 "(GET_IMAGE_WIDTH(a),GET_IMAGE_HEIGHT(a),GET_IMAGE_DEPTH(a),a,b,c)";
-        defines = defines + "\n#define WRITE_" + itr->first + "_IMAGE(a,b,c) write_buffer" + sdim + "d" + itr->second.GetTypeId() +
+        defines = defines + "\n#define WRITE_" + itr->first + "_IMAGE(a,b,c) write_buffer" + sdim + "d" + abbrType +
                 "(GET_IMAGE_WIDTH(a),GET_IMAGE_HEIGHT(a),GET_IMAGE_DEPTH(a),a,b,c)";
         defines = defines + "\n";
     }
@@ -135,6 +139,33 @@ std::string Kernel::DefineDimensionality(Buffer& data)
     }
     return dim;
 }
+
+
+std::string Kernel::TypeAbbr(const std::string type) const
+{
+    if (type.compare("float") == 0)
+    {
+        return "f";
+    }
+    else if (type.compare("char") == 0)
+    {
+        return  "c";
+    }
+    else if (type.compare("uchar") == 0)
+    {
+        return  "uc";
+    }
+    else if (type.compare("int") == 0)
+    {
+        return  "i";
+    }
+    else if (type.compare("uint") == 0)
+    {
+        return  "ui";
+    }
+    return ""; 
+}
+
 
 void Kernel::CompileKernel()
 {

--- a/src/cleMaximumZProjectionKernel.cpp
+++ b/src/cleMaximumZProjectionKernel.cpp
@@ -24,15 +24,13 @@ void MaximumZProjectionKernel::Execute(Buffer& in, Buffer& out)
 
     // Set the arguments of the kernel
     cl_int clError;
-    cl_mem src_mem = in.GetPointer();
-    cl_mem dst_mem = out.GetPointer();
-    clError = clSetKernelArg(this->GetKernel(), 0, sizeof(cl_mem), &dst_mem);
+    clError = clSetKernelArg(this->GetKernel(), 0, sizeof(out.GetData()), &(out.GetData()));
     if (clError != CL_SUCCESS)
     {
         std::cerr << "Argument error! Fail to set argument : " << getOpenCLErrorString(clError) << std::endl;
         throw clError;
     }
-    clError = clSetKernelArg(this->GetKernel(), 1, sizeof(cl_mem), &src_mem);
+    clError = clSetKernelArg(this->GetKernel(), 1, sizeof(in.GetData()), &(in.GetData()));
     if (clError != CL_SUCCESS)
     {
         std::cerr << "Argument error! Fail to set argument : " << getOpenCLErrorString(clError) << std::endl;

--- a/src/cleMean2DSphereKernel.cpp
+++ b/src/cleMean2DSphereKernel.cpp
@@ -25,29 +25,27 @@ void Mean2DSphereKernel::Execute(Buffer& in, Buffer& out, int radius_x, int radi
 
     // Set the arguments of the kernel
     cl_int clError;
-    cl_mem src_mem = in.GetPointer();
-    cl_mem dst_mem = out.GetPointer();
-    clError = clSetKernelArg(this->GetKernel(), 0, sizeof(cl_mem), &dst_mem);
+    clError = clSetKernelArg(this->GetKernel(), 0, sizeof(out.GetData()), &(out.GetData()));
     if (clError != CL_SUCCESS)
     {
         std::cerr << "Argument error! Fail to set argument : " << getOpenCLErrorString(clError) << std::endl;
         throw clError;
     }
-    clError = clSetKernelArg(this->GetKernel(), 1, sizeof(cl_mem), &src_mem);
+    clError = clSetKernelArg(this->GetKernel(), 1, sizeof(in.GetData()), &(in.GetData()));
     if (clError != CL_SUCCESS)
     {
         std::cerr << "Argument error! Fail to set argument : " << getOpenCLErrorString(clError) << std::endl;
         throw clError;
     }
     int kernel_size_x = (radius_x * 2 + 1);
-    clError = clSetKernelArg(this->GetKernel(), 2, sizeof(int), (void *)&kernel_size_x);
+    clError = clSetKernelArg(this->GetKernel(), 2, sizeof(int), &kernel_size_x);
     if (clError != CL_SUCCESS)
     {
         std::cerr << "Argument error! Fail to set argument : " << getOpenCLErrorString(clError) << std::endl;
         throw clError;
     }
     int kernel_size_y = (radius_y * 2 + 1);
-    clError = clSetKernelArg(this->GetKernel(), 3, sizeof(int), (void*)&kernel_size_y);
+    clError = clSetKernelArg(this->GetKernel(), 3, sizeof(int), &kernel_size_y);
     if (clError != CL_SUCCESS)
     {
         std::cerr << "Argument error! Fail to set argument : " << getOpenCLErrorString(clError) << std::endl;

--- a/src/cleObject.cpp
+++ b/src/cleObject.cpp
@@ -1,0 +1,50 @@
+
+#include "cleObject.h"
+
+namespace cle
+{
+
+std::string Object::DataTypeToString(const DataType t) const
+{
+    switch (t)
+    {
+        case Float:  return "float";
+        case Char:   return "char";
+        case UChar:  return "uchar";
+        case Int:    return "int";
+        case UInt:   return "uint";
+        case Short:  return "short";
+        case UShort: return "ushort";
+        default:     return "unknown";
+    }
+}
+
+Object::DataType Object::StringToDataType(const std::string t) const
+{
+    if(t == "float")       return Object::DataType::Float;
+    else if(t == "char")   return Object::DataType::Char;
+    else if(t == "uchar")  return Object::DataType::UChar;
+    else if(t == "int")    return Object::DataType::Int;
+    else if(t == "uint")   return Object::DataType::UInt;
+    else if(t == "short")  return Object::DataType::Short;
+    else if(t == "ushort") return Object::DataType::UShort;
+    else                   return Object::DataType::Float;
+}
+
+std::string Object::ObjectTypeToString(const ObjectType o) const
+{
+    switch (o)
+    {
+        case Scalar:  return "Scalar";
+        case Buffer:  return "Buffer";
+        case Image2d: return "Image2d";
+        default:      return "Unknown";
+    }
+}
+
+std::ostream& operator<<(std::ostream& os, const Object& p)
+{
+    return os << p.ToString();
+}
+
+} // namespace cle

--- a/src/cleScalar.cpp
+++ b/src/cleScalar.cpp
@@ -23,7 +23,7 @@ Scalar::~Scalar()
 {
 }
 
-float Scalar::GetValue()
+float& Scalar::GetData()
 {
     return value;
 }

--- a/src/cleScalar.cpp
+++ b/src/cleScalar.cpp
@@ -1,0 +1,52 @@
+/*  CLIc - version 0.1 - Copyright 2020 Stéphane Rigaud, Robert Haase,
+*   Institut Pasteur Paris, Max Planck Institute for Molecular Cell Biology and Genetics Dresden
+*
+*   CLIc is part of the clEsperanto project http://clesperanto.net 
+*
+*   This file is subject to the terms and conditions defined in
+*   file 'LICENSE.txt', which is part of this source code package.
+*/
+
+
+#include "cleScalar.h"
+#include <iostream>
+
+namespace cle
+{
+
+Scalar::Scalar(float v)
+{
+    value = v;
+}
+
+Scalar::~Scalar()
+{
+}
+
+float Scalar::GetValue()
+{
+    return value;
+}
+
+std::string Scalar::GetObjectType() const
+{
+    return this->ObjectTypeToString(O);
+}
+
+std::string Scalar::GetDataType() const
+{
+    return this->DataTypeToString(T);
+}
+
+std::string Scalar::ToString() const
+{
+    // std::string typ = ", dtype=" + typeId + "(" + type + ")";
+    // std::string dim = "size=[" + std::to_string(dimensions[0]) + "," 
+    //                            + std::to_string(dimensions[1]) + "," 
+    //                            + std::to_string(dimensions[2]) + "]"; 
+    // return "clScalar<" + dim + typ + ">";
+    return "";
+}
+
+} // namespace cle
+

--- a/src/cleSmallerOrEqualConstantKernel.cpp
+++ b/src/cleSmallerOrEqualConstantKernel.cpp
@@ -26,9 +26,7 @@ void SmallerOrEqualConstantKernel::Execute(Buffer& in, Buffer& out, float scalar
 
     // Set the arguments of the kernel
     cl_int clError;
-    cl_mem src_mem = in.GetPointer();
-    cl_mem dst_mem = out.GetPointer();
-    clError = clSetKernelArg(this->GetKernel(), 0, sizeof(cl_mem), &src_mem);
+    clError = clSetKernelArg(this->GetKernel(), 0, sizeof(in.GetData()), &(in.GetData()));
     if (clError != CL_SUCCESS)
     {
         std::cerr << "Argument error! Fail to set argument : " << getOpenCLErrorString(clError) << std::endl;
@@ -40,7 +38,7 @@ void SmallerOrEqualConstantKernel::Execute(Buffer& in, Buffer& out, float scalar
         std::cerr << "Argument error! Fail to set argument : " << getOpenCLErrorString(clError) << std::endl;
         throw clError;
     }
-    clError = clSetKernelArg(this->GetKernel(), 2, sizeof(cl_mem), &dst_mem);
+    clError = clSetKernelArg(this->GetKernel(), 2, sizeof(out.GetData()), &(out.GetData()));
     if (clError != CL_SUCCESS)
     {
         std::cerr << "Argument error! Fail to set argument : " << getOpenCLErrorString(clError) << std::endl;


### PR DESCRIPTION
Abstract cleObject class from which we can inherit cleBuffer and other data class.
This allows to treat the same way a Buffer, an Image2d, or a simple Scalar when dealing with the kernels parameters.

same as the cleKernel, we aim for a strong template to insure consistency in the nomenclature and object construction. 
Still naive implementation and may evolve in future.