### PR TITLE
fix: Define CL_TARGET_OPENCL_VERSION

### DIFF
--- a/include/cleGPU.h
+++ b/include/cleGPU.h
@@ -11,6 +11,10 @@
 #ifndef __cleGPU_h
 #define __cleGPU_h
 
+#ifndef CL_TARGET_OPENCL_VERSION
+#  define CL_TARGET_OPENCL_VERSION 120
+#endif
+
 #ifdef __APPLE__
 #include <OpenCL/opencl.h>
 #else

--- a/include/cleKernel.h
+++ b/include/cleKernel.h
@@ -11,6 +11,10 @@
 #ifndef __cleKernel_h
 #define __cleKernel_h
 
+#ifndef CL_TARGET_OPENCL_VERSION
+#  define CL_TARGET_OPENCL_VERSION 120
+#endif
+
 #ifdef __APPLE__
 #include <OpenCL/opencl.h>
 #else


### PR DESCRIPTION
To address:

/usr/local/include/CL/cl_version.h:22:104: note: #pragma message:
cl_version.h: CL_TARGET_OPENCL_VERSION is not defined. Defaulting to 300
(OpenCL 3.0)
   22 | #pragma message("cl_version.h: CL_TARGET_OPENCL_VERSION is not
   defined. Defaulting to 300 (OpenCL 3.0)")

Define the target version for OpenCL 1.2. This is required by the
Khronos official OpenCL headers:

  https://github.com/KhronosGroup/OpenCL-Headers
