### PR TITLE
introduction of clImage object

### DIFF
--- a/clic/includes/core/cleBuffer.hpp
+++ b/clic/includes/core/cleBuffer.hpp
@@ -30,8 +30,9 @@ public:
     int GetWidth() const;
     int GetHeight() const;
     int GetDepth() const;
-    int GetDimension() const;
     int GetSize() const;
+    int GetDimension() const;
+
     std::array<int,3> GetShape() const;
 
     const char* GetDataType() const;
@@ -42,7 +43,6 @@ public:
 private:
     cl::Buffer m_Object;
     std::array<int,3> m_Shape = {1, 1, 1};
-    int m_Dimension = 1;
     DataType m_Type = Buffer::FLOAT;
 };
 

--- a/clic/includes/core/cleBuffer.hpp
+++ b/clic/includes/core/cleBuffer.hpp
@@ -25,7 +25,7 @@ public:
     Buffer(cl::Buffer, int[3], DataType=FLOAT);
     ~Buffer() =default;
 
-    cl::Buffer GetObject() const;
+    const cl::Buffer GetObject() const;
     
     int GetWidth() const;
     int GetHeight() const;

--- a/clic/includes/core/cleImage2D.hpp
+++ b/clic/includes/core/cleImage2D.hpp
@@ -25,7 +25,7 @@ public:
     Image2D(cl::Image2D, int[3], DataType=FLOAT);
     ~Image2D() =default;
 
-    cl::Image2D GetObject() const;
+    const cl::Image2D GetObject() const;
     
     int GetWidth() const;
     int GetHeight() const;
@@ -36,9 +36,6 @@ public:
     std::array<int,3> GetShape() const;
     std::array<int,3> GetOrigin() const;
     std::array<int,3> GetRegion() const;
-
-    void SetOrigin(std::array<int,3>);
-    void SetRegion(std::array<int,3>);
 
     const char* GetDataType() const;
     bool IsDataType(const char*) const;

--- a/clic/includes/core/cleImage2D.hpp
+++ b/clic/includes/core/cleImage2D.hpp
@@ -1,0 +1,60 @@
+#ifndef __cleImage2D_hpp
+#define __cleImage2D_hpp
+
+#include "clic.hpp"
+#include <string>
+#include <memory>
+#include <algorithm>
+#include <iterator>
+#include <array>
+
+#include "cleLightObject.hpp"
+
+namespace cle
+{
+
+class Image2D : public LightObject
+{
+public: 
+
+    enum DataType { FLOAT, DOUBLE, INT, UINT, CHAR, UCHAR, SHORT, USHORT };
+
+    Image2D();
+    Image2D(cl::Image2D, DataType=FLOAT);
+    Image2D(cl::Image2D, std::array<int,3>, DataType=FLOAT);
+    Image2D(cl::Image2D, int[3], DataType=FLOAT);
+    ~Image2D() =default;
+
+    cl::Image2D GetObject() const;
+    
+    int GetWidth() const;
+    int GetHeight() const;
+    int GetDepth() const;
+    int GetSize() const;
+    int GetDimension() const;
+
+    std::array<int,3> GetShape() const;
+    std::array<int,3> GetOrigin() const;
+    std::array<int,3> GetRegion() const;
+
+    void SetOrigin(std::array<int,3>);
+    void SetRegion(std::array<int,3>);
+
+    const char* GetDataType() const;
+    bool IsDataType(const char*) const;
+    const char* GetObjectType() const;
+    bool IsObjectType(const char*) const;
+
+private:
+    cl::Image2D m_Object;
+    std::array<int,3> m_Shape {1, 1, 1};
+    std::array<int,3> m_Origin {0, 0, 0};
+    std::array<int,3> m_Region {1, 1, 1};
+    cl::ImageFormat m_ImageFormat;
+
+    DataType m_Type = Image2D::FLOAT;
+};
+
+}
+
+#endif //__cleImage2D_hpp

--- a/clic/includes/core/cleKernel.hpp
+++ b/clic/includes/core/cleKernel.hpp
@@ -17,6 +17,7 @@
 #include "cleLightObject.hpp"
 #include "cleScalar.hpp"
 #include "cleBuffer.hpp"
+#include "cleImage2D.hpp"
 
 
 #include "cleGPU.hpp"
@@ -54,7 +55,8 @@ protected:
     std::string TypeAbbr(const char*) const;
 
     // Populate Parameter list with data and tag
-    void AddObject(Buffer, std::string);
+    void AddObject(Buffer&, std::string);
+    void AddObject(Image2D&, std::string);
     void AddObject(int, std::string);
     void AddObject(float, std::string);
 

--- a/clic/includes/core/cleLightObject.hpp
+++ b/clic/includes/core/cleLightObject.hpp
@@ -13,9 +13,19 @@ namespace cle
 
 class LightObject
 {
+protected:
+    int m_Dimension;
+
 public: 
     LightObject() =default;
     virtual ~LightObject() = default;
+
+    virtual int GetDimension() const =0;
+
+    virtual int GetWidth() const =0;
+    virtual int GetHeight() const =0;
+    virtual int GetDepth() const =0;
+
 
     virtual const char* GetDataType() const =0;
     virtual bool IsDataType(const char*) const =0;    

--- a/clic/includes/core/cleOperations.hpp
+++ b/clic/includes/core/cleOperations.hpp
@@ -7,45 +7,180 @@
 
 namespace cle
 {
-    // copy but do not type cast, prefere copy kernel for safety, to be discussed
-    // template<class T>
-    // void FillBuffer(cl::Buffer src, T value, size_t size, std::shared_ptr<GPU> gpu)
-    // {
-    //     gpu->GetCommandQueueManager().GetCommandQueue().enqueueFillBuffer(
-    //         src, value, 0, size
-    //         ); 
-    // }
+// copy but do not type cast, prefere copy kernel for safety, to be discussed
+// template<class T>
+// void FillBuffer(cl::Buffer src, T value, size_t size, std::shared_ptr<GPU> gpu)
+// {
+//     gpu->GetCommandQueueManager().GetCommandQueue().enqueueFillBuffer(
+//         src, value, 0, size
+//         ); 
+// }
 
-    template<class T>
-    void CopyBuffer(cl::Buffer src, cl::Buffer dst, size_t size, std::shared_ptr<GPU> gpu)
+template<class T>
+void CopyBuffer(cl::Buffer src, cl::Buffer dst, size_t size, std::shared_ptr<GPU> gpu)
+{
+    try
     {
         gpu->GetCommandQueueManager().GetCommandQueue().enqueueCopyBuffer(
             src, dst, 0, 0, sizeof(T) * size
         );
     }
-
-    template<class T>
-    cl::Buffer CreateBuffer(size_t size, std::shared_ptr<GPU> gpu)
+    catch(cl::Error& e)
     {
-        return cl::Buffer(
-            gpu->GetContextManager().GetContext(), CL_MEM_READ_WRITE, sizeof(T) * size);
+        std::cerr << "Operation CopyBuffer : Fail to copy buffer ..." << std::endl;
+        std::cerr << "\tException caught! " << e.what() << " error code " << e.err() << std::endl;
     }
+}
 
-    template<class T>
-    void WriteBuffer(cl::Buffer obj, T* arr, size_t size, std::shared_ptr<GPU> gpu)
+template<class T>
+cl::Buffer CreateBuffer(size_t size, std::shared_ptr<GPU> gpu)
+{
+    return cl::Buffer(
+        gpu->GetContextManager().GetContext(), CL_MEM_READ_WRITE, sizeof(T) * size);
+}
+
+template<class T>
+void WriteBuffer(cl::Buffer obj, T* arr, size_t size, std::shared_ptr<GPU> gpu)
+{
+    try
     {
         gpu->GetCommandQueueManager().GetCommandQueue().enqueueWriteBuffer(
             obj, CL_TRUE, 0, sizeof(T) * size, arr
         );
     }
+    catch(cl::Error& e)
+    {
+        std::cerr << "Operation WriteBuffer : Fail to write in buffer ..." << std::endl;
+        std::cerr << "\tException caught! " << e.what() << " error code " << e.err() << std::endl;
+    }
+}
 
-    template<class T>
-    void ReadBuffer(cl::Buffer obj, T* arr, size_t size, std::shared_ptr<GPU> gpu)
+template<class T>
+void ReadBuffer(cl::Buffer obj, T* arr, size_t size, std::shared_ptr<GPU> gpu)
+{
+    try
     {
         gpu->GetCommandQueueManager().GetCommandQueue().enqueueReadBuffer(
             obj, CL_TRUE, 0, sizeof(T) * size, arr
         );
     }
+    catch(cl::Error& e)
+    {
+        std::cerr << "Operation ReadBuffer : Fail to read buffer ..." << std::endl;
+        std::cerr << "\tException caught! " << e.what() << " error code " << e.err() << std::endl;
+    }
+}
+
+template<class T>
+cl::Image1D CreateImage1D(int* size, std::shared_ptr<GPU> gpu)
+{
+    cl::ImageFormat grayscale(CL_INTENSITY, CL_FLOAT);
+    return cl::Image1D( gpu->GetContextManager().GetContext(), CL_MEM_READ_WRITE, grayscale, size[0]);
+}
+
+template<class T>
+cl::Image2D CreateImage2D(int* size, std::shared_ptr<GPU> gpu)
+{
+    cl::ImageFormat grayscale(CL_INTENSITY, CL_FLOAT);
+    return cl::Image2D( gpu->GetContextManager().GetContext(), CL_MEM_READ_WRITE, grayscale, size[0], size[1]);
+}
+
+template<class T>
+cl::Image3D CreateImage3D(int* size, std::shared_ptr<GPU> gpu)
+{
+    cl::ImageFormat grayscale(CL_INTENSITY, CL_FLOAT);
+    return cl::Image3D( gpu->GetContextManager().GetContext(), CL_MEM_READ_WRITE, grayscale, size[0], size[1], size[2]);
+}
+
+template<class T>
+void WriteImage(cl::Image* obj, T* arr, std::shared_ptr<GPU> gpu)
+{
+    cl::size_type row_pitch = obj->getImageInfo<CL_IMAGE_ROW_PITCH>();
+    cl::size_type slice_pitch = obj->getImageInfo<CL_IMAGE_SLICE_PITCH>();
+    cl::size_type width = obj->getImageInfo<CL_IMAGE_WIDTH>();
+    cl::size_type height = obj->getImageInfo<CL_IMAGE_HEIGHT>();
+    cl::size_type depth = obj->getImageInfo<CL_IMAGE_DEPTH>(); 
+
+    if(height == 0) height += 1;
+    if(depth == 0) depth += 1;
+    std::array<cl::size_type,3> origin {0,0,0};
+    std::array<cl::size_type,3> region {width, height, depth};
+
+    try
+    {
+        gpu->GetCommandQueueManager().GetCommandQueue().enqueueWriteImage (
+            *obj, CL_TRUE, origin, region, row_pitch, slice_pitch, arr
+        );
+    }
+    catch(cl::Error& e)
+    {
+        std::cerr << "Operation WriteImage2D : Fail to write image 2d ..." << std::endl;
+        std::cerr << "\tException caught! " << e.what() << " error code " << e.err() << std::endl;
+    }
+}
+
+template<class T>
+void WriteImage1D(cl::Image1D obj, T* arr, std::shared_ptr<GPU> gpu)
+{
+    WriteImage<T>(&obj, arr, gpu);
+}
+
+template<class T>
+void WriteImage2D(cl::Image2D obj, T* arr, std::shared_ptr<GPU> gpu)
+{
+    WriteImage<T>(&obj, arr, gpu);
+}
+
+template<class T>
+void WriteImage3D(cl::Image3D obj, T* arr, std::shared_ptr<GPU> gpu)
+{
+    WriteImage<T>(&obj, arr, gpu);
+}  
+
+template<class T>
+void ReadImage(cl::Image* obj, T* arr, std::shared_ptr<GPU> gpu)
+{
+    cl::size_type row_pitch = obj->getImageInfo<CL_IMAGE_ROW_PITCH>();
+    cl::size_type slice_pitch = obj->getImageInfo<CL_IMAGE_SLICE_PITCH>(); // should be 0
+    cl::size_type width = obj->getImageInfo<CL_IMAGE_WIDTH>();
+    cl::size_type height = obj->getImageInfo<CL_IMAGE_HEIGHT>();
+    cl::size_type depth = obj->getImageInfo<CL_IMAGE_DEPTH>();  // should be 0
+
+    if(height == 0) height += 1;
+    if(depth == 0) depth += 1;
+    std::array<cl::size_type,3> origin {0,0,0};
+    std::array<cl::size_type,3> region {width, height, depth};
+
+    try
+    {
+        gpu->GetCommandQueueManager().GetCommandQueue().enqueueReadImage(
+            *obj, CL_TRUE, origin, region, row_pitch, slice_pitch, arr
+        );
+    }
+    catch(cl::Error& e)
+    {
+        std::cerr << "Operation ReadBuffer : Fail to read buffer ..." << std::endl;
+        std::cerr << "\tException caught! " << e.what() << " error code " << e.err() << std::endl;
+    }
+}
+
+template<class T>
+void ReadImage1D(cl::Image1D obj, T* arr, std::shared_ptr<GPU> gpu)
+{
+    ReadImage<T>(&obj, arr, gpu);
+}
+
+template<class T>
+void ReadImage2D(cl::Image2D obj, T* arr, std::shared_ptr<GPU> gpu)
+{
+    ReadImage<T>(&obj, arr, gpu);
+}
+
+template<class T>
+void ReadImage3D(cl::Image3D obj, T* arr, std::shared_ptr<GPU> gpu)
+{
+    ReadImage<T>(&obj, arr, gpu);
+}  
 
 } // namespace cle
 

--- a/clic/includes/core/cleOperations.hpp
+++ b/clic/includes/core/cleOperations.hpp
@@ -7,7 +7,7 @@
 
 namespace cle
 {
-    // Removed for now, prefere to use kernel operation Set()
+    // copy but do not type cast, prefere copy kernel for safety, to be discussed
     // template<class T>
     // void FillBuffer(cl::Buffer src, T value, size_t size, std::shared_ptr<GPU> gpu)
     // {
@@ -36,14 +36,6 @@ namespace cle
     {
         gpu->GetCommandQueueManager().GetCommandQueue().enqueueWriteBuffer(
             obj, CL_TRUE, 0, sizeof(T) * size, arr
-        );
-    }
-
-    template<class T>
-    void WriteBuffer(cl::Buffer obj, T val, std::shared_ptr<GPU> gpu)
-    {
-        gpu->GetCommandQueueManager().GetCommandQueue().enqueueWriteBuffer(
-            obj, CL_TRUE, 0, sizeof(T) * 1, val
         );
     }
 

--- a/clic/includes/core/cleScalar.hpp
+++ b/clic/includes/core/cleScalar.hpp
@@ -32,7 +32,7 @@ public:
     int GetDepth() const;
     int GetDimension() const;
 
-    T GetObject() const;
+    const T GetObject() const;
 
     const char* GetDataType() const;
 
@@ -78,7 +78,7 @@ int Scalar<T>::GetDimension() const
 }
 
 template<class T>
-T Scalar<T>::GetObject() const { return this->m_Object; }
+const T Scalar<T>::GetObject() const { return this->m_Object; }
 
 template<class T>
 const char* Scalar<T>::GetDataType() const { return TemplateToString(); }

--- a/clic/includes/core/cleScalar.hpp
+++ b/clic/includes/core/cleScalar.hpp
@@ -23,9 +23,14 @@ protected:
     const char * TemplateToString() const;
 public: 
 
-    Scalar() =default;
+    Scalar();
     Scalar(T);
     ~Scalar() =default;
+
+    int GetWidth() const;
+    int GetHeight() const;
+    int GetDepth() const;
+    int GetDimension() const;
 
     T GetObject() const;
 
@@ -38,9 +43,39 @@ public:
     
 };
 
+template<class T>
+Scalar<T>::Scalar() : m_Object(0) 
+{
+}
 
 template<class T>
-Scalar<T>::Scalar(T _d) : m_Object(_d) {}
+Scalar<T>::Scalar(T _d) : m_Object(_d)
+{
+}
+
+template<class T>
+int Scalar<T>::GetWidth() const
+{
+    return 1;
+}
+
+template<class T>
+int Scalar<T>::GetHeight() const
+{
+    return 1;
+}
+
+template<class T>
+int Scalar<T>::GetDepth() const
+{
+    return 1;
+}
+
+template<class T>
+int Scalar<T>::GetDimension() const
+{
+    return 1;
+}
 
 template<class T>
 T Scalar<T>::GetObject() const { return this->m_Object; }

--- a/clic/includes/tier1/cleAddImageAndScalarKernel.hpp
+++ b/clic/includes/tier1/cleAddImageAndScalarKernel.hpp
@@ -22,6 +22,8 @@ public:
 
     void SetInput(Buffer&);
     void SetOutput(Buffer&);
+    void SetInput(Image2D&);
+    void SetOutput(Image2D&);
     void SetScalar(float);
     void Execute();
 

--- a/clic/src/core/cleBuffer.cpp
+++ b/clic/src/core/cleBuffer.cpp
@@ -3,21 +3,18 @@
 namespace cle
 {
 
-Buffer::Buffer(cl::Buffer _ocl, DataType _t) : m_Object(_ocl), m_Type(_t) 
-{}
+Buffer::Buffer(cl::Buffer _ocl, DataType _t) : m_Object(_ocl), m_Type(_t)
+{
+}
 
 Buffer::Buffer(cl::Buffer _ocl, std::array<int,3> _dim, DataType _t) : m_Object(_ocl), m_Type(_t) 
 {
     std::copy(_dim.begin(), _dim.end(), m_Shape.begin());
-    if (m_Shape[2] > 1) m_Dimension = 3;
-    else if (m_Shape[1] > 1) m_Dimension = 2;
 }
 
 Buffer::Buffer(cl::Buffer _ocl, int _dim[3], DataType _t) : m_Object(_ocl), m_Type(_t) 
 {
     std::copy(_dim, _dim+3, m_Shape.begin());
-    if (m_Shape[2] > 1) m_Dimension = 3;
-    else if (m_Shape[1] > 1) m_Dimension = 2;
 }
 
 
@@ -41,15 +38,18 @@ int Buffer::GetDepth() const
     return this->m_Shape[2]; 
 }
 
-int Buffer::GetDimension() const 
-{ 
-    return this->m_Dimension; 
-}
-
 int Buffer::GetSize() const 
 { 
     return this->m_Shape[0]*this->m_Shape[1]*this->m_Shape[2]; 
 }
+
+int Buffer::GetDimension() const 
+{ 
+    if (m_Shape[2] > 1) return 3;
+    if (m_Shape[1] > 1) return 2;
+    return  1;
+}
+
 
 std::array<int,3> Buffer::GetShape() const 
 {

--- a/clic/src/core/cleBuffer.cpp
+++ b/clic/src/core/cleBuffer.cpp
@@ -18,7 +18,7 @@ Buffer::Buffer(cl::Buffer _ocl, int _dim[3], DataType _t) : m_Object(_ocl), m_Ty
 }
 
 
-cl::Buffer Buffer::GetObject() const 
+const cl::Buffer Buffer::GetObject() const 
 { 
     return this->m_Object; 
 }

--- a/clic/src/core/cleImage2D.cpp
+++ b/clic/src/core/cleImage2D.cpp
@@ -24,7 +24,7 @@ Image2D::Image2D(cl::Image2D _ocl, int _dim[3] , DataType _t) : m_Object(_ocl), 
     m_ImageFormat.image_channel_data_type = _ocl.getImageInfo<CL_IMAGE_FORMAT>().image_channel_data_type;  
 }
 
-cl::Image2D Image2D::GetObject() const
+const cl::Image2D Image2D::GetObject() const
 {
     return this->m_Object; 
 }
@@ -67,16 +67,6 @@ std::array<int,3> Image2D::GetOrigin() const
 std::array<int,3> Image2D::GetRegion() const
 {
     return m_Region;
-}
-
-void Image2D::SetOrigin(std::array<int,3> _origin)
-{
-    std::copy(_origin.begin(), _origin.end(), m_Origin.begin());    
-}
-
-void Image2D::SetRegion(std::array<int,3> _region)
-{
-    std::copy(_region.begin(), _region.end(), m_Region.begin());    
 }
 
 const char* Image2D::GetDataType() const

--- a/clic/src/core/cleImage2D.cpp
+++ b/clic/src/core/cleImage2D.cpp
@@ -1,0 +1,119 @@
+#include "cleImage2D.hpp"
+
+namespace cle
+{
+Image2D::Image2D()
+{}
+
+Image2D::Image2D(cl::Image2D _ocl, DataType _t) : m_Object(_ocl), m_Type(_t)
+{}
+
+Image2D::Image2D(cl::Image2D _ocl, std::array<int,3> _dim, DataType _t) : m_Object(_ocl), m_Type(_t)
+{
+    std::copy(_dim.begin(), _dim.end(), m_Shape.begin());
+    std::copy(_dim.begin(), _dim.end(), m_Region.begin());
+    m_ImageFormat.image_channel_order = _ocl.getImageInfo<CL_IMAGE_FORMAT>().image_channel_order;          
+    m_ImageFormat.image_channel_data_type = _ocl.getImageInfo<CL_IMAGE_FORMAT>().image_channel_data_type;  
+}
+
+Image2D::Image2D(cl::Image2D _ocl, int _dim[3] , DataType _t) : m_Object(_ocl), m_Type(_t)
+{
+    std::copy(_dim, _dim+3, m_Shape.begin());
+    std::copy(_dim, _dim+3, m_Region.begin());
+    m_ImageFormat.image_channel_order = _ocl.getImageInfo<CL_IMAGE_FORMAT>().image_channel_order;          
+    m_ImageFormat.image_channel_data_type = _ocl.getImageInfo<CL_IMAGE_FORMAT>().image_channel_data_type;  
+}
+
+cl::Image2D Image2D::GetObject() const
+{
+    return this->m_Object; 
+}
+
+int Image2D::GetWidth() const
+{
+    return m_Shape[0];
+}
+
+int Image2D::GetHeight() const
+{
+    return m_Shape[1];
+}
+
+int Image2D::GetDepth() const
+{
+    return m_Shape[2];
+}
+
+int Image2D::GetSize() const
+{
+    return m_Shape[0]*m_Shape[1]*m_Shape[2];
+}
+
+int Image2D::GetDimension() const
+{
+    return 2;
+}
+
+std::array<int,3> Image2D::GetShape() const
+{
+    return m_Shape;
+}
+
+std::array<int,3> Image2D::GetOrigin() const
+{
+    return m_Origin;
+}
+
+std::array<int,3> Image2D::GetRegion() const
+{
+    return m_Region;
+}
+
+void Image2D::SetOrigin(std::array<int,3> _origin)
+{
+    std::copy(_origin.begin(), _origin.end(), m_Origin.begin());    
+}
+
+void Image2D::SetRegion(std::array<int,3> _region)
+{
+    std::copy(_region.begin(), _region.end(), m_Region.begin());    
+}
+
+const char* Image2D::GetDataType() const
+{
+    if (m_Type == DataType::FLOAT) return "float"; 
+    if (m_Type == DataType::DOUBLE) return "double"; 
+    if (m_Type == DataType::INT) return "int"; 
+    if (m_Type == DataType::CHAR) return "char"; 
+    if (m_Type == DataType::UINT) return "uint"; 
+    if (m_Type == DataType::UCHAR) return "uchar"; 
+    if (m_Type == DataType::SHORT) return "short"; 
+    if (m_Type == DataType::USHORT) return "ushort"; 
+    return "";
+}
+
+bool Image2D::IsDataType(const char* str) const
+{
+    size_t size = strlen(str);
+    if (m_Type == DataType::FLOAT && strncmp("float", str, size) == 0) return true; 
+    if (m_Type == DataType::DOUBLE && strncmp("double", str, size) == 0) return true; 
+    if (m_Type == DataType::INT && strncmp("int", str, size) == 0) return true; 
+    if (m_Type == DataType::CHAR && strncmp("char", str, size) == 0) return true;
+    if (m_Type == DataType::UINT && strncmp("uint", str, size) == 0) return true; 
+    if (m_Type == DataType::UCHAR && strncmp("uchar", str, size) == 0) return true; 
+    if (m_Type == DataType::SHORT && strncmp("short", str, size) == 0) return true; 
+    if (m_Type == DataType::USHORT && strncmp("ushort", str, size) == 0) return true; 
+    return false;
+}   
+
+const char* Image2D::GetObjectType() const
+{
+    return "image2dimage2d";
+}
+
+bool Image2D::IsObjectType(const char* str) const
+{
+    return strncmp("image2d", str, strlen(str)) == 0;
+}
+
+}

--- a/clic/src/core/cleKernel.cpp
+++ b/clic/src/core/cleKernel.cpp
@@ -11,7 +11,6 @@ void Kernel::ManageDimensions(std::string tag)
         auto it = m_ParameterList.find(tag);
         if (it != m_ParameterList.end())
         {
-            // std::shared_ptr<cle::Buffer> object = std::dynamic_pointer_cast<cle::Buffer>(m_ParameterList.at(tag));
             if(m_ParameterList.at(tag)->GetDimension() == 3)
             {
                 m_DimensionTag = "_3d";
@@ -63,10 +62,8 @@ std::string Kernel::LoadDefines()
     // loop on parameters
     for (auto itr = m_ParameterList.begin(); itr != m_ParameterList.end(); ++itr)
     {
-        // if (itr->second->IsObjectType(LightObject::cleBuffer))
-        if (!itr->second->IsObjectType("scalar"))
+        if (!itr->second->IsObjectType("scalar"))  // argument is buffer or image
         {     
-            // std::shared_ptr<cle::Buffer> object = std::dynamic_pointer_cast<cle::Buffer>(itr->second);
             std::string tagObject = itr->first;
             std::string objectType = itr->second->GetObjectType();
             std::string dataType = itr->second->GetDataType();
@@ -248,11 +245,11 @@ void Kernel::AddObject(Buffer &o, std::string t)
         auto it = m_ParameterList.find(t.c_str()); 
         if (it != m_ParameterList.end())
         {
-            it->second = std::make_shared<Buffer>(o);
+            it->second = std::make_shared< cle::Buffer >(o);
         }
         else    
         {
-            m_ParameterList.insert(std::make_pair(t.c_str(), std::make_shared<Buffer>(o)));
+            m_ParameterList.insert(std::make_pair(t.c_str(), std::make_shared< cle::Buffer >(o)));
         }
     }
     else
@@ -268,11 +265,11 @@ void Kernel::AddObject(Image2D &o, std::string t)
         auto it = m_ParameterList.find(t.c_str()); 
         if (it != m_ParameterList.end())
         {
-            it->second = std::make_shared<Image2D>(o);
+            it->second = std::make_shared< cle::Image2D >(o);
         }
         else    
         {
-            m_ParameterList.insert(std::make_pair(t.c_str(), std::make_shared<Image2D>(o)));
+            m_ParameterList.insert(std::make_pair(t.c_str(), std::make_shared< cle::Image2D >(o)));
         }
     }
     else

--- a/clic/src/core/cleKernel.cpp
+++ b/clic/src/core/cleKernel.cpp
@@ -323,7 +323,6 @@ void Kernel::AddObject(float o, std::string t)
 void Kernel::BuildProgramKernel()
 {
     std::string sources = GenerateSources();
-    std::cout << "sources are generated\n";
     std::hash<std::string> hasher;
     size_t source_hash = hasher(sources);
     if(m_CurrentHash != source_hash)  

--- a/clic/src/tier1/cleAddImageAndScalarKernel.cpp
+++ b/clic/src/tier1/cleAddImageAndScalarKernel.cpp
@@ -24,6 +24,16 @@ void AddImageAndScalarKernel::SetOutput(Buffer& x)
     this->AddObject(x, "dst");
 }
 
+void AddImageAndScalarKernel::SetInput(Image2D& x)
+{
+    this->AddObject(x, "src");
+}
+
+void AddImageAndScalarKernel::SetOutput(Image2D& x)
+{
+    this->AddObject(x, "dst");
+}
+
 void AddImageAndScalarKernel::SetScalar(float x)
 {
     this->AddObject(x, "scalar");
@@ -31,10 +41,15 @@ void AddImageAndScalarKernel::SetScalar(float x)
 
 void AddImageAndScalarKernel::Execute()
 {
+    std::cout << "dim" << std::endl;
     this->ManageDimensions("dst");
+    std::cout << "build" << std::endl;
     this->BuildProgramKernel();
+    std::cout << "arg" << std::endl;
     this->SetArguments();
+    std::cout << "enqueue" << std::endl;
     this->EnqueueKernel();
+    std::cout << "done" << std::endl;
 }
 } // namespace cle
 

--- a/clic/tests/CMakeLists.txt
+++ b/clic/tests/CMakeLists.txt
@@ -34,6 +34,11 @@ add_dependencies(scalar_test CLIc)
 target_link_libraries(scalar_test PRIVATE CLIc::CLIc)
 add_test(NAME scalar_test COMMAND ${CMAKE_CURRENT_BINARY_DIR}/scalar_test)
 
+add_executable(image_test image_test.cpp)
+add_dependencies(image_test CLIc) 
+target_link_libraries(image_test PRIVATE CLIc::CLIc)
+add_test(NAME image_test COMMAND ${CMAKE_CURRENT_BINARY_DIR}/image_test)
+
 add_executable(operations_test operations_test.cpp)
 add_dependencies(operations_test CLIc) 
 target_link_libraries(operations_test PRIVATE CLIc::CLIc)

--- a/clic/tests/image_test.cpp
+++ b/clic/tests/image_test.cpp
@@ -82,20 +82,15 @@ int main(int argc, char** argv)
     std::fill (B.begin(),B.end(), 0.0f);
     std::fill (C.begin(),C.end(), 101.0f);
 
+
+    // kernel run using Image2D object
+    
     cl::Image2D ocl_imageA = cle::CreateImage2D<float>(dims, cle->GetGPU());
     cle::WriteImage2D<float>(ocl_imageA, A.data(), cle->GetGPU());
     cle::Image2D ImageA (ocl_imageA, dims);
 
     cl::Image2D ocl_imageB = cle::CreateImage2D<float>(dims, cle->GetGPU());
     cle::Image2D ImageB (ocl_imageB, dims);
-
-
-    // cl::Buffer ocl_imageA = cle::CreateBuffer<float>(A.size(), cle->GetGPU());
-    // cle::WriteBuffer<float>(ocl_imageA, A.data(), A.size(), cle->GetGPU());
-    // cle::Buffer ImageA (ocl_imageA, dims);
-
-    // cl::Buffer ocl_imageB = cle::CreateBuffer<float>(B.size(), cle->GetGPU());
-    // cle::Buffer ImageB (ocl_imageB, dims);
 
     cle::AddImageAndScalarKernel kernel (cle->GetGPU());
     kernel.SetScalar(100.0f);
@@ -104,6 +99,22 @@ int main(int argc, char** argv)
     kernel.Execute();
 
     cle::ReadImage2D<float>(ImageB.GetObject(), B.data(), cle->GetGPU());
+
+    // kernel run using Buffer object
+
+    // cl::Buffer ocl_imageA = cle::CreateBuffer<float>(A.size(), cle->GetGPU());
+    // cle::WriteBuffer<float>(ocl_imageA, A.data(), A.size(), cle->GetGPU());
+    // cle::Buffer ImageA (ocl_imageA, dims);
+
+    // cl::Buffer ocl_imageB = cle::CreateBuffer<float>(B.size(), cle->GetGPU());
+    // cle::Buffer ImageB (ocl_imageB, dims);
+
+    // cle::AddImageAndScalarKernel kernel (cle->GetGPU());
+    // kernel.SetScalar(100.0f);
+    // kernel.SetInput(ImageA);
+    // kernel.SetOutput(ImageB);
+    // kernel.Execute();
+
     // cle::ReadBuffer<float>(ImageB.GetObject(), B.data(), ImageB.GetSize(), cle->GetGPU());
 
     float diff = 0;

--- a/clic/tests/image_test.cpp
+++ b/clic/tests/image_test.cpp
@@ -1,0 +1,123 @@
+
+#include "clesperanto.hpp"
+
+#include "cleAddImageAndScalarKernel.hpp"
+
+int main(int argc, char** argv)
+{
+    cle::Clesperanto* cle = new cle::Clesperanto();
+
+    {
+    int dims[3] = {16, 1, 1};
+    std::vector<float> A (dims[0]*dims[1]*dims[2]); 
+    std::vector<float> B (dims[0]*dims[1]*dims[2]); 
+
+    std::fill (A.begin(),A.end(), 10.0f);
+    std::fill (B.begin(),B.end(), 1.0f);
+
+
+    cl::Image1D image = cle::CreateImage1D<float>(dims, cle->GetGPU());
+    cle::WriteImage1D<float>(image, A.data(), cle->GetGPU());
+    cle::ReadImage1D<float>(image, B.data(), cle->GetGPU());
+
+    float diff = 0;
+    for (size_t i=0; i<A.size(); i++)
+    {
+        diff += A[i] - B[i];
+    }
+    std::cout << diff << std::endl;
+    }
+
+    {
+    int dims[3] = {16, 16, 1};
+    std::vector<float> A (dims[0]*dims[1]*dims[2]); 
+    std::vector<float> B (dims[0]*dims[1]*dims[2]); 
+
+    std::fill (A.begin(),A.end(), 10.0f);
+    std::fill (B.begin(),B.end(), 1.0f);
+
+
+    cl::Image2D image = cle::CreateImage2D<float>(dims, cle->GetGPU());
+    cle::WriteImage2D<float>(image, A.data(), cle->GetGPU());
+    cle::ReadImage2D<float>(image, B.data(), cle->GetGPU());
+
+    float diff = 0;
+    for (size_t i=0; i<A.size(); i++)
+    {
+        diff += A[i] - B[i];
+    }
+    std::cout << diff << std::endl;
+    }
+
+    {
+    int dims[3] = {16, 16, 5};
+    std::vector<float> A (dims[0]*dims[1]*dims[2]); 
+    std::vector<float> B (dims[0]*dims[1]*dims[2]); 
+
+    std::fill (A.begin(),A.end(), 10.0f);
+    std::fill (B.begin(),B.end(), 1.0f);
+
+
+    cl::Image3D image = cle::CreateImage3D<float>(dims, cle->GetGPU());
+    cle::WriteImage3D<float>(image, A.data(), cle->GetGPU());
+    cle::ReadImage3D<float>(image, B.data(), cle->GetGPU());
+
+    float diff = 0;
+    for (size_t i=0; i<A.size(); i++)
+    {
+        diff += A[i] - B[i];
+    }
+    std::cout << diff << std::endl;
+    }
+
+
+
+    {
+    int dims[3] = {16, 16, 1};
+    std::vector<float> A (dims[0]*dims[1]*dims[2]); 
+    std::vector<float> B (dims[0]*dims[1]*dims[2]); 
+    std::vector<float> C (dims[0]*dims[1]*dims[2]); 
+
+    std::fill (A.begin(),A.end(), 1.0f);
+    std::fill (B.begin(),B.end(), 0.0f);
+    std::fill (C.begin(),C.end(), 101.0f);
+
+    cl::Image2D ocl_imageA = cle::CreateImage2D<float>(dims, cle->GetGPU());
+    cle::WriteImage2D<float>(ocl_imageA, A.data(), cle->GetGPU());
+    cle::Image2D ImageA (ocl_imageA, dims);
+
+    cl::Image2D ocl_imageB = cle::CreateImage2D<float>(dims, cle->GetGPU());
+    cle::Image2D ImageB (ocl_imageB, dims);
+
+
+    // cl::Buffer ocl_imageA = cle::CreateBuffer<float>(A.size(), cle->GetGPU());
+    // cle::WriteBuffer<float>(ocl_imageA, A.data(), A.size(), cle->GetGPU());
+    // cle::Buffer ImageA (ocl_imageA, dims);
+
+    // cl::Buffer ocl_imageB = cle::CreateBuffer<float>(B.size(), cle->GetGPU());
+    // cle::Buffer ImageB (ocl_imageB, dims);
+
+    cle::AddImageAndScalarKernel kernel (cle->GetGPU());
+    kernel.SetScalar(100.0f);
+    kernel.SetInput(ImageA);
+    kernel.SetOutput(ImageB);
+    kernel.Execute();
+
+    cle::ReadImage2D<float>(ImageB.GetObject(), B.data(), cle->GetGPU());
+    // cle::ReadBuffer<float>(ImageB.GetObject(), B.data(), ImageB.GetSize(), cle->GetGPU());
+
+    float diff = 0;
+    for (size_t i=0; i<A.size(); i++)
+    {
+        diff += B[i] - C[i];
+    }
+    std::cout << diff << std::endl;
+    }
+
+
+
+
+
+
+    return 0;
+}


### PR DESCRIPTION
First draft to introduce clImage object. For now focusing on cl::Image2D of type Float

add new operations for creation/writing/reading Image1D, Image2D, Image3D ([operations.hpp](https://github.com/clEsperanto/CLIc_prototype/compare/master...StRigaud:master#diff-f415f61f8ef5e40545f3ebeab3705ea444d2cdcb7f5987da080a596ec36ddf95))
new data class cle::Image2D inherited from cle::LightObject ([cle::Image2D](https://github.com/clEsperanto/CLIc_prototype/compare/master...StRigaud:master#diff-43d89ec72f4944de4a41a784a85da9b2a445c25bba3fcc8a6f5b6685b8ea1cbc))
Extention of cle::Kernel to manage cle::Image2D condition ([cle::Kernel](https://github.com/clEsperanto/CLIc_prototype/compare/master...StRigaud:master#diff-bbc5f4b117fc1d130817c3b59f2d31a28e83371e2efe932da20ee64c9d7ecbcd))
Quick testing of a kernel execution with Image2D object ([test](https://github.com/clEsperanto/CLIc_prototype/compare/master...StRigaud:master#diff-d6cdb6019eab4267f40ee5bdbe9d1422f9fc8665bf0284430ad7c7c09dae9fb2))

Test execution fail when setting argument to kernel.
For both image OCL return -38 error code :  CL_INVALID_MEM_OBJECT -> memobj is not a valid OpenCL memory object.

After some checking, nothing indicate issues on the object, so I suspect it is linked to the OCL code contained in the preamble and/or the data defines generated at execution which are different for Image. Some external eyes would be welcome ! (@haesleinhuepf :wave: )  

I doubt I will merge this PR as the introduction of image data type may require some code cleaning and improvement. But first we need to make the test pass ... 

