### PR TITLE
Fix preamble

### DIFF
--- a/clic/preamble.cl
+++ b/clic/preamble.cl
@@ -208,7 +208,7 @@ inline uchar2 read_buffer3duc(int read_buffer_width, int read_buffer_height, int
     return (uchar2){buffer_var[pos_in_buffer],0};
 }
 
-inline short2 read_buffer3di(int read_buffer_width, int read_buffer_height, int read_buffer_depth, __global short * buffer_var, sampler_t sampler, int4 position )
+inline short2 read_buffer3ds(int read_buffer_width, int read_buffer_height, int read_buffer_depth, __global short * buffer_var, sampler_t sampler, int4 position )
 {
     int4 pos = (int4){position.x, position.y, position.z, 0};
     if (true) { // if (CLK_ADDRESS_CLAMP_TO_EDGE & sampler) {
@@ -226,7 +226,7 @@ inline short2 read_buffer3di(int read_buffer_width, int read_buffer_height, int 
     return (short2){buffer_var[pos_in_buffer],0};
 }
 
-inline ushort2 read_buffer3dui(int read_buffer_width, int read_buffer_height, int read_buffer_depth, __global ushort * buffer_var, sampler_t sampler, int4 position )
+inline ushort2 read_buffer3dus(int read_buffer_width, int read_buffer_height, int read_buffer_depth, __global ushort * buffer_var, sampler_t sampler, int4 position )
 {
     int4 pos = (int4){position.x, position.y, position.z, 0};
     if (true) { // if (CLK_ADDRESS_CLAMP_TO_EDGE & sampler) {
@@ -242,6 +242,41 @@ inline ushort2 read_buffer3dui(int read_buffer_width, int read_buffer_height, in
         return (ushort2){0, 0};
     }
     return (ushort2){buffer_var[pos_in_buffer],0};
+}
+inline int2 read_buffer3di(int read_buffer_width, int read_buffer_height, int read_buffer_depth, __global int * buffer_var, sampler_t sampler, int4 position )
+{
+    int4 pos = (int4){position.x, position.y, position.z, 0};
+    if (true) { // if (CLK_ADDRESS_CLAMP_TO_EDGE & sampler) {
+        pos.x = max((MINMAX_TYPE)pos.x, (MINMAX_TYPE)0);
+        pos.y = max((MINMAX_TYPE)pos.y, (MINMAX_TYPE)0);
+        pos.z = max((MINMAX_TYPE)pos.z, (MINMAX_TYPE)0);
+        pos.x = min((MINMAX_TYPE)pos.x, (MINMAX_TYPE)read_buffer_width - 1);
+        pos.y = min((MINMAX_TYPE)pos.y, (MINMAX_TYPE)read_buffer_height - 1);
+        pos.z = min((MINMAX_TYPE)pos.z, (MINMAX_TYPE)read_buffer_depth - 1);
+    }
+    int pos_in_buffer = pos.x + pos.y * read_buffer_width + pos.z * read_buffer_width * read_buffer_height;
+    if (pos.x < 0 || pos.x >= read_buffer_width || pos.y < 0 || pos.y >= read_buffer_height || pos.z < 0 || pos.z >= read_buffer_depth) {
+        return (int2){0, 0};
+    }
+    return (int2){buffer_var[pos_in_buffer],0};
+}
+
+inline uint2 read_buffer3dui(int read_buffer_width, int read_buffer_height, int read_buffer_depth, __global uint * buffer_var, sampler_t sampler, int4 position )
+{
+    int4 pos = (int4){position.x, position.y, position.z, 0};
+    if (true) { // if (CLK_ADDRESS_CLAMP_TO_EDGE & sampler) {
+        pos.x = max((MINMAX_TYPE)pos.x, (MINMAX_TYPE)0);
+        pos.y = max((MINMAX_TYPE)pos.y, (MINMAX_TYPE)0);
+        pos.z = max((MINMAX_TYPE)pos.z, (MINMAX_TYPE)0);
+        pos.x = min((MINMAX_TYPE)pos.x, (MINMAX_TYPE)read_buffer_width - 1);
+        pos.y = min((MINMAX_TYPE)pos.y, (MINMAX_TYPE)read_buffer_height - 1);
+        pos.z = min((MINMAX_TYPE)pos.z, (MINMAX_TYPE)read_buffer_depth - 1);
+    }
+    int pos_in_buffer = pos.x + pos.y * read_buffer_width + pos.z * read_buffer_width * read_buffer_height;
+    if (pos.x < 0 || pos.x >= read_buffer_width || pos.y < 0 || pos.y >= read_buffer_height || pos.z < 0 || pos.z >= read_buffer_depth) {
+        return (uint2){0, 0};
+    }
+    return (uint2){buffer_var[pos_in_buffer],0};
 }
 
 inline float2 read_buffer3df(int read_buffer_width, int read_buffer_height, int read_buffer_depth, __global float* buffer_var, sampler_t sampler, int4 position )
@@ -280,7 +315,7 @@ inline void write_buffer3duc(int write_buffer_width, int write_buffer_height, in
     buffer_var[pos_in_buffer] = value;
 }
 
-inline void write_buffer3di(int write_buffer_width, int write_buffer_height, int write_buffer_depth, __global short * buffer_var, int4 pos, short value )
+inline void write_buffer3ds(int write_buffer_width, int write_buffer_height, int write_buffer_depth, __global short * buffer_var, int4 pos, short value )
 {
     int pos_in_buffer = pos.x + pos.y * write_buffer_width + pos.z * write_buffer_width * write_buffer_height;
     if (pos.x < 0 || pos.x >= write_buffer_width || pos.y < 0 || pos.y >= write_buffer_height || pos.z < 0 || pos.z >= write_buffer_depth) {
@@ -289,7 +324,26 @@ inline void write_buffer3di(int write_buffer_width, int write_buffer_height, int
     buffer_var[pos_in_buffer] = value;
 }
 
-inline void write_buffer3dui(int write_buffer_width, int write_buffer_height, int write_buffer_depth, __global ushort * buffer_var, int4 pos, ushort value )
+inline void write_buffer3dus(int write_buffer_width, int write_buffer_height, int write_buffer_depth, __global ushort * buffer_var, int4 pos, ushort value )
+{
+    int pos_in_buffer = pos.x + pos.y * write_buffer_width + pos.z * write_buffer_width * write_buffer_height;
+    if (pos.x < 0 || pos.x >= write_buffer_width || pos.y < 0 || pos.y >= write_buffer_height || pos.z < 0 || pos.z >= write_buffer_depth) {
+        return;
+    }
+    buffer_var[pos_in_buffer] = value;
+}
+
+
+inline void write_buffer3di(int write_buffer_width, int write_buffer_height, int write_buffer_depth, __global int * buffer_var, int4 pos, int value )
+{
+    int pos_in_buffer = pos.x + pos.y * write_buffer_width + pos.z * write_buffer_width * write_buffer_height;
+    if (pos.x < 0 || pos.x >= write_buffer_width || pos.y < 0 || pos.y >= write_buffer_height || pos.z < 0 || pos.z >= write_buffer_depth) {
+        return;
+    }
+    buffer_var[pos_in_buffer] = value;
+}
+
+inline void write_buffer3dui(int write_buffer_width, int write_buffer_height, int write_buffer_depth, __global uint * buffer_var, int4 pos, uint value )
 {
     int pos_in_buffer = pos.x + pos.y * write_buffer_width + pos.z * write_buffer_width * write_buffer_height;
     if (pos.x < 0 || pos.x >= write_buffer_width || pos.y < 0 || pos.y >= write_buffer_height || pos.z < 0 || pos.z >= write_buffer_depth) {
@@ -339,7 +393,7 @@ inline uchar2 read_buffer2duc(int read_buffer_width, int read_buffer_height, int
     return (uchar2){buffer_var[pos_in_buffer],0};
 }
 
-inline short2 read_buffer2di(int read_buffer_width, int read_buffer_height, int read_buffer_depth, __global short * buffer_var, sampler_t sampler, int2 position )
+inline short2 read_buffer2ds(int read_buffer_width, int read_buffer_height, int read_buffer_depth, __global short * buffer_var, sampler_t sampler, int2 position )
 {
     int2 pos = (int2){position.x, position.y};
     if (true) { // if (CLK_ADDRESS_CLAMP_TO_EDGE & sampler) {
@@ -355,7 +409,7 @@ inline short2 read_buffer2di(int read_buffer_width, int read_buffer_height, int 
     return (short2){buffer_var[pos_in_buffer],0};
 }
 
-inline ushort2 read_buffer2dui(int read_buffer_width, int read_buffer_height, int read_buffer_depth, __global ushort * buffer_var, sampler_t sampler, int2 position )
+inline ushort2 read_buffer2dus(int read_buffer_width, int read_buffer_height, int read_buffer_depth, __global ushort * buffer_var, sampler_t sampler, int2 position )
 {
     int2 pos = (int2){position.x, position.y};
     if (true) { // if (CLK_ADDRESS_CLAMP_TO_EDGE & sampler) {
@@ -369,6 +423,38 @@ inline ushort2 read_buffer2dui(int read_buffer_width, int read_buffer_height, in
         return (ushort2){0, 0};
     }
     return (ushort2){buffer_var[pos_in_buffer],0};
+}
+
+inline int2 read_buffer2di(int read_buffer_width, int read_buffer_height, int read_buffer_depth, __global int * buffer_var, sampler_t sampler, int2 position )
+{
+    int2 pos = (int2){position.x, position.y};
+    if (true) { // if (CLK_ADDRESS_CLAMP_TO_EDGE & sampler) {
+        pos.x = max((MINMAX_TYPE)pos.x, (MINMAX_TYPE)0);
+        pos.y = max((MINMAX_TYPE)pos.y, (MINMAX_TYPE)0);
+        pos.x = min((MINMAX_TYPE)pos.x, (MINMAX_TYPE)read_buffer_width - 1);
+        pos.y = min((MINMAX_TYPE)pos.y, (MINMAX_TYPE)read_buffer_height - 1);
+    }
+    int pos_in_buffer = pos.x + pos.y * read_buffer_width;
+    if (pos.x < 0 || pos.x >= read_buffer_width || pos.y < 0 || pos.y >= read_buffer_height) {
+        return (int2){0, 0};
+    }
+    return (int2){buffer_var[pos_in_buffer],0};
+}
+
+inline uint2 read_buffer2dui(int read_buffer_width, int read_buffer_height, int read_buffer_depth, __global uint * buffer_var, sampler_t sampler, int2 position )
+{
+    int2 pos = (int2){position.x, position.y};
+    if (true) { // if (CLK_ADDRESS_CLAMP_TO_EDGE & sampler) {
+        pos.x = max((MINMAX_TYPE)pos.x, (MINMAX_TYPE)0);
+        pos.y = max((MINMAX_TYPE)pos.y, (MINMAX_TYPE)0);
+        pos.x = min((MINMAX_TYPE)pos.x, (MINMAX_TYPE)read_buffer_width - 1);
+        pos.y = min((MINMAX_TYPE)pos.y, (MINMAX_TYPE)read_buffer_height - 1);
+    }
+    int pos_in_buffer = pos.x + pos.y * read_buffer_width;
+    if (pos.x < 0 || pos.x >= read_buffer_width || pos.y < 0 || pos.y >= read_buffer_height) {
+        return (uint2){0, 0};
+    }
+    return (uint2){buffer_var[pos_in_buffer],0};
 }
 
 inline float2 read_buffer2df(int read_buffer_width, int read_buffer_height, int read_buffer_depth, __global float* buffer_var, sampler_t sampler, int2 position )
@@ -405,7 +491,7 @@ inline void write_buffer2duc(int write_buffer_width, int write_buffer_height, in
     buffer_var[pos_in_buffer] = value;
 }
 
-inline void write_buffer2di(int write_buffer_width, int write_buffer_height, int write_buffer_depth, __global short * buffer_var, int2 pos, short value )
+inline void write_buffer2ds(int write_buffer_width, int write_buffer_height, int write_buffer_depth, __global short * buffer_var, int2 pos, short value )
 {
     int pos_in_buffer = pos.x + pos.y * write_buffer_width;
     if (pos.x < 0 || pos.x >= write_buffer_width || pos.y < 0 || pos.y >= write_buffer_height) {
@@ -414,7 +500,25 @@ inline void write_buffer2di(int write_buffer_width, int write_buffer_height, int
     buffer_var[pos_in_buffer] = value;
 }
 
-inline void write_buffer2dui(int write_buffer_width, int write_buffer_height, int write_buffer_depth, __global ushort * buffer_var, int2 pos, ushort value )
+inline void write_buffer2dus(int write_buffer_width, int write_buffer_height, int write_buffer_depth, __global ushort * buffer_var, int2 pos, ushort value )
+{
+    int pos_in_buffer = pos.x + pos.y * write_buffer_width;
+    if (pos.x < 0 || pos.x >= write_buffer_width || pos.y < 0 || pos.y >= write_buffer_height) {
+        return;
+    }
+    buffer_var[pos_in_buffer] = value;
+}
+
+inline void write_buffer2di(int write_buffer_width, int write_buffer_height, int write_buffer_depth, __global int * buffer_var, int2 pos, int value )
+{
+    int pos_in_buffer = pos.x + pos.y * write_buffer_width;
+    if (pos.x < 0 || pos.x >= write_buffer_width || pos.y < 0 || pos.y >= write_buffer_height) {
+        return;
+    }
+    buffer_var[pos_in_buffer] = value;
+}
+
+inline void write_buffer2dui(int write_buffer_width, int write_buffer_height, int write_buffer_depth, __global uint * buffer_var, int2 pos, uint value )
 {
     int pos_in_buffer = pos.x + pos.y * write_buffer_width;
     if (pos.x < 0 || pos.x >= write_buffer_width || pos.y < 0 || pos.y >= write_buffer_height) {

--- a/clic/src/core/cleKernel.cpp
+++ b/clic/src/core/cleKernel.cpp
@@ -138,10 +138,10 @@ std::string Kernel::TypeAbbr(const char* t_str) const
     if (strncmp("float", t_str, size) == 0)  return "f";
     if (strncmp("char", t_str, size) == 0)   return "c";
     if (strncmp("uchar", t_str, size) == 0)  return "uc";
-    // if (strncmp("int", t_str, size) == 0)    return "i";    // Missing definition type in preamble
-    // if (strncmp("uint", t_str, size) == 0)   return "ui";   // Missing definition type in preamble
-    // if (strncmp("short", t_str, size) == 0)    return "s";  // Missing definition type in preamble
-    // if (strncmp("ushort", t_str, size) == 0)   return "us"; // Missing definition type in preamble
+    if (strncmp("short", t_str, size) == 0)  return "s";
+    if (strncmp("ushort", t_str, size) == 0) return "us";
+    if (strncmp("int", t_str, size) == 0)    return "i";
+    if (strncmp("uint", t_str, size) == 0)   return "ui";
     return "?"; 
 }
 

--- a/clic/tests/kernel_test.cpp
+++ b/clic/tests/kernel_test.cpp
@@ -202,6 +202,239 @@ int main(int argc, char **argv)
     }
     }
 
+    {
+    using TYPE = int;
+    auto gpu = std::make_shared<cle::GPU>();
+    gpu->WaitForKernelToFinish();
+
+    std::array<int,3> dims = {10, 1, 1};
+    std::vector<TYPE> data (dims[0]*dims[1]*dims[2]); 
+    std::vector<TYPE> valid (dims[0]*dims[1]*dims[2]); 
+    std::fill (data.begin(),data.end(), 10.0f);
+    std::fill (valid.begin(),valid.end(), 100.0f);
+
+    cle::Buffer buff_A = gpu->PushBuffer<TYPE>(data, dims);
+    cle::Buffer buff_B = gpu->CreateBuffer<TYPE>(dims);
+
+    cle::AddImageAndScalarKernel kernel(gpu);
+    kernel.SetInput(buff_A);
+    kernel.SetOutput(buff_B);
+    kernel.SetScalar(90.0f);
+    kernel.Execute();
+
+    std::vector<TYPE> res = gpu->Pull<TYPE>(buff_B);
+    
+
+    float diff = 0;
+    for (int i =0; i< res.size(); i++)
+    {
+        diff += valid[i] - res[i];
+    }
+    if (diff > 0)
+    {
+        std::cout << "test kernel fail - diff = " << diff << std::endl;
+        return EXIT_FAILURE;
+    }
+    else
+    {
+        std::cout << "test kernel pass - diff = " << diff << std::endl;
+    }
+    }
+
+    {
+    using TYPE = unsigned int;
+    auto gpu = std::make_shared<cle::GPU>();
+    gpu->WaitForKernelToFinish();
+
+        std::array<int,3> dims = {10, 1, 1};
+    std::vector<TYPE> data (dims[0]*dims[1]*dims[2]); 
+    std::vector<TYPE> valid (dims[0]*dims[1]*dims[2]); 
+    std::fill (data.begin(),data.end(), 10.0f);
+    std::fill (valid.begin(),valid.end(), 100.0f);
+
+    cle::Buffer buff_A = gpu->PushBuffer<TYPE>(data, dims);
+    cle::Buffer buff_B = gpu->CreateBuffer<TYPE>(dims);
+
+    cle::AddImageAndScalarKernel kernel(gpu);
+    kernel.SetInput(buff_A);
+    kernel.SetOutput(buff_B);
+    kernel.SetScalar(90.0f);
+    kernel.Execute();
+
+    std::vector<TYPE> res = gpu->Pull<TYPE>(buff_B);
+    
+
+    float diff = 0;
+    for (int i =0; i< res.size(); i++)
+    {
+        diff += valid[i] - res[i];
+    }
+    if (diff > 0)
+    {
+        std::cout << "test kernel fail - diff = " << diff << std::endl;
+        return EXIT_FAILURE;
+    }
+    else
+    {
+        std::cout << "test kernel pass - diff = " << diff << std::endl;
+    }
+    }
+
+    {
+    using TYPE = char;
+    auto gpu = std::make_shared<cle::GPU>();
+    gpu->WaitForKernelToFinish();
+
+        std::array<int,3> dims = {10, 1, 1};
+    std::vector<TYPE> data (dims[0]*dims[1]*dims[2]); 
+    std::vector<TYPE> valid (dims[0]*dims[1]*dims[2]); 
+    std::fill (data.begin(),data.end(), 10.0f);
+    std::fill (valid.begin(),valid.end(), 100.0f);
+
+    cle::Buffer buff_A = gpu->PushBuffer<TYPE>(data, dims);
+    cle::Buffer buff_B = gpu->CreateBuffer<TYPE>(dims);
+
+    cle::AddImageAndScalarKernel kernel(gpu);
+    kernel.SetInput(buff_A);
+    kernel.SetOutput(buff_B);
+    kernel.SetScalar(90.0f);
+    kernel.Execute();
+
+    std::vector<TYPE> res = gpu->Pull<TYPE>(buff_B);
+    
+
+    float diff = 0;
+    for (int i =0; i< res.size(); i++)
+    {
+        diff += valid[i] - res[i];
+    }
+    if (diff > 0)
+    {
+        std::cout << "test kernel fail - diff = " << diff << std::endl;
+        return EXIT_FAILURE;
+    }
+    else
+    {
+        std::cout << "test kernel pass - diff = " << diff << std::endl;
+    }
+    }
+
+    {
+    using TYPE = unsigned char;
+    auto gpu = std::make_shared<cle::GPU>();
+    gpu->WaitForKernelToFinish();
+
+        std::array<int,3> dims = {10, 1, 1};
+    std::vector<TYPE> data (dims[0]*dims[1]*dims[2]); 
+    std::vector<TYPE> valid (dims[0]*dims[1]*dims[2]); 
+    std::fill (data.begin(),data.end(), 10.0f);
+    std::fill (valid.begin(),valid.end(), 100.0f);
+
+    cle::Buffer buff_A = gpu->PushBuffer<TYPE>(data, dims);
+    cle::Buffer buff_B = gpu->CreateBuffer<TYPE>(dims);
+
+    cle::AddImageAndScalarKernel kernel(gpu);
+    kernel.SetInput(buff_A);
+    kernel.SetOutput(buff_B);
+    kernel.SetScalar(90.0f);
+    kernel.Execute();
+
+    std::vector<TYPE> res = gpu->Pull<TYPE>(buff_B);
+    
+
+    float diff = 0;
+    for (int i =0; i< res.size(); i++)
+    {
+        diff += valid[i] - res[i];
+    }
+    if (diff > 0)
+    {
+        std::cout << "test kernel fail - diff = " << diff << std::endl;
+        return EXIT_FAILURE;
+    }
+    else
+    {
+        std::cout << "test kernel pass - diff = " << diff << std::endl;
+    }
+    }
+
+    {
+    using TYPE = short;
+    auto gpu = std::make_shared<cle::GPU>();
+    gpu->WaitForKernelToFinish();
+
+    std::array<int,3> dims = {10, 1, 1};
+    std::vector<TYPE> data (dims[0]*dims[1]*dims[2]); 
+    std::vector<TYPE> valid (dims[0]*dims[1]*dims[2]); 
+    std::fill (data.begin(),data.end(), 10.0f);
+    std::fill (valid.begin(),valid.end(), 100.0f);
+
+    cle::Buffer buff_A = gpu->PushBuffer<TYPE>(data, dims);
+    cle::Buffer buff_B = gpu->CreateBuffer<TYPE>(dims);
+
+    cle::AddImageAndScalarKernel kernel(gpu);
+    kernel.SetInput(buff_A);
+    kernel.SetOutput(buff_B);
+    kernel.SetScalar(90.0f);
+    kernel.Execute();
+
+    std::vector<TYPE> res = gpu->Pull<TYPE>(buff_B);
+    
+
+    float diff = 0;
+    for (int i =0; i< res.size(); i++)
+    {
+        diff += valid[i] - res[i];
+    }
+    if (diff > 0)
+    {
+        std::cout << "test kernel fail - diff = " << diff << std::endl;
+        return EXIT_FAILURE;
+    }
+    else
+    {
+        std::cout << "test kernel pass - diff = " << diff << std::endl;
+    }
+    }
+
+    {
+    using TYPE = unsigned short;
+    auto gpu = std::make_shared<cle::GPU>();
+    gpu->WaitForKernelToFinish();
+
+    std::array<int,3> dims = {10, 1, 1};
+    std::vector<TYPE> data (dims[0]*dims[1]*dims[2]); 
+    std::vector<TYPE> valid (dims[0]*dims[1]*dims[2]); 
+    std::fill (data.begin(),data.end(), 10.0f);
+    std::fill (valid.begin(),valid.end(), 100.0f);
+
+    cle::Buffer buff_A = gpu->PushBuffer<TYPE>(data, dims);
+    cle::Buffer buff_B = gpu->CreateBuffer<TYPE>(dims);
+
+    cle::AddImageAndScalarKernel kernel(gpu);
+    kernel.SetInput(buff_A);
+    kernel.SetOutput(buff_B);
+    kernel.SetScalar(90.0f);
+    kernel.Execute();
+
+    std::vector<TYPE> res = gpu->Pull<TYPE>(buff_B);
+    
+
+    float diff = 0;
+    for (int i =0; i< res.size(); i++)
+    {
+        diff += valid[i] - res[i];
+    }
+    if (diff > 0)
+    {
+        std::cout << "test kernel fail - diff = " << diff << std::endl;
+        return EXIT_FAILURE;
+    }
+    else
+    {
+        std::cout << "test kernel pass - diff = " << diff << std::endl;
+    }
+    }
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Hi Stephane @StRigaud ,

this closes #46. I changed the type-abbreviation `i` and `ui`. It now means `int` and `unsigned int`. Furthermore, I added the abbreviations `s` and `us` for `short` and `unsigned short`. 

One question before you consider merging: Shall I add/enable a test somewhere?

Best,
Robert