### PR TITLE
BUG: Resolve ambiguous `std::abs` reference via `<cmath>`

### DIFF
--- a/clic/include/core/utils.hpp
+++ b/clic/include/core/utils.hpp
@@ -7,7 +7,7 @@
 #include <iostream>
 #include <limits>
 
-#include <math.h>
+#include <cmath>
 
 template<class type>
 bool IsDifferent(std::vector<type>& output, std::vector<type>& valid)


### PR DESCRIPTION
Hi all, this is a small fix for a build error we've observed in ITKCLEsperanto in building macOS Python wheels. Please see https://github.com/InsightSoftwareConsortium/ITKCLEsperanto/issues/29 for an error trace.

`<cmath>` is the appropriate header to include here to populate the `std::` namespace. From [https://en.cppreference.com/w/cpp/header](https://en.cppreference.com/w/cpp/header):

> With the exception of [complex.h](https://en.cppreference.com/w/cpp/header/ccomplex) , each xxx.h header included in the C++ standard library places in the global namespace each name that the corresponding cxxx header would have placed in the std namespace.

> Notes: xxx.h headers are deprecated in C++98 and undeprecated in C++23. These headers are discouraged for pure C++ code, but not subject to future removal.

ITKCLEsperanto macOS Python wheels build successfully against this development branch. See [passing CI results](https://github.com/InsightSoftwareConsortium/ITKCLEsperanto/runs/8239585910?check_suite_focus=true).