### PR TITLE
COMP: Require only CMake Python3 components that are used in build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,8 @@ if(NOT OpenCL_FOUND)
     find_package(OpenCL REQUIRED)
 endif()
 
-if(NOT Python_FOUND)
-    find_package(Python COMPONENTS Interpreter Development REQUIRED)
+if(NOT Python3_Interpreter_FOUND)
+    find_package(Python3 COMPONENTS Interpreter REQUIRED)
 endif()
 
 # Library sources

--- a/clic/CMakeLists.txt
+++ b/clic/CMakeLists.txt
@@ -37,20 +37,20 @@ add_dependencies(${LIBRARY_NAME} generate_preamble generate_kernels generate_ker
 ### File auto-generation target
 add_custom_target(
     generate_preamble ALL
-    COMMAND ${Python_EXECUTABLE} ${UTILITIES_DIR}/convert_clij_to_header.py ${OCL_PREAMBLE_FILE} ${CMAKE_CURRENT_SOURCE_DIR}/kernels/
+    COMMAND ${Python3_EXECUTABLE} ${UTILITIES_DIR}/convert_clij_to_header.py ${OCL_PREAMBLE_FILE} ${CMAKE_CURRENT_SOURCE_DIR}/kernels/
     BYPRODUCTS ${CMAKE_CURRENT_SOURCE_DIR}/kernels/cle_preamble.h
     COMMENT "Generating cle_preamble header."
 )
 add_custom_target(
     generate_kernels ALL
-    COMMAND ${Python_EXECUTABLE} ${UTILITIES_DIR}/convert_clij_to_header.py ${OCL_KERNELS_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/kernels/
+    COMMAND ${Python3_EXECUTABLE} ${UTILITIES_DIR}/convert_clij_to_header.py ${OCL_KERNELS_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/kernels/
     BYPRODUCTS ${CMAKE_CURRENT_SOURCE_DIR}/kernels 
     COMMENT "Generating kernels header from clij opencl files."
 )
 add_dependencies(generate_kernels generate_preamble)
 add_custom_target(
     generate_kernels_list ALL
-    COMMAND ${Python_EXECUTABLE} ${UTILITIES_DIR}/generate_kernellist_header.py ${CMAKE_CURRENT_SOURCE_DIR}/include
+    COMMAND ${Python3_EXECUTABLE} ${UTILITIES_DIR}/generate_kernellist_header.py ${CMAKE_CURRENT_SOURCE_DIR}/include
     BYPRODUCTS ${CMAKE_CURRENT_SOURCE_DIR}/include/core/cleKernelList.h 
     COMMENT "Generating cleKernelList header."
 )


### PR DESCRIPTION
Updates to Python3 and relaxes CMake Python requirements so that only the component used in the build (interpreter) is required. Cherry-picks changes from [https://github.com/clEsperanto/CLIc_prototype/pull/94](https://github.com/clEsperanto/CLIc_prototype/pull/94) limited to CMake Python requirement.

Resolves ITKCLEsperanto build issue described at https://github.com/InsightSoftwareConsortium/ITKCLEsperanto/issues/30 where `CLIc_prototype` dependency fails to build in the absence of the Python development library. ITKCLEsperanto Linux Python builds successfully against this development branch: [https://github.com/InsightSoftwareConsortium/ITKCLEsperanto/runs/8261050209?check_suite_focus=true](https://github.com/InsightSoftwareConsortium/ITKCLEsperanto/runs/8261050209?check_suite_focus=true).