### PR TITLE
Use CMAKE to git clone ocl repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,4 @@
-[submodule "thirdparty/opencl/ocl-headers"]
-	path = thirdparty/opencl/ocl-headers
-	url = https://github.com/KhronosGroup/OpenCL-Headers.git
-[submodule "thirdparty/opencl/ocl-clhpp"]
-	path = thirdparty/opencl/ocl-clhpp
-	url = https://github.com/KhronosGroup/OpenCL-CLHPP.git
+
 [submodule "thirdparty/clesperanto-kernels"]
 	path = thirdparty/clesperanto-kernels
 	url = https://github.com/clEsperanto/clij-opencl-kernels.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,33 +23,33 @@ endif()
 add_subdirectory(${THIRDPARTY_DIR})
 add_subdirectory(${LIBRARY_DIR})
 
-# # Build and run tests
-# if(BUILD_TESTING)
-#     include(CTest)
-#     add_subdirectory(${PROJECT_SOURCE_DIR}/tests)
-# endif(BUILD_TESTING)
+# Build and run tests
+if(BUILD_TESTING)
+    include(CTest)
+    add_subdirectory(${PROJECT_SOURCE_DIR}/tests)
+endif(BUILD_TESTING)
 
-# # Build and run benchmark
-# if(BUILD_BENCHMARK)
-#     add_subdirectory(benchmark)
-# endif(BUILD_BENCHMARK)
+# Build and run benchmark
+if(BUILD_BENCHMARK)
+    add_subdirectory(benchmark)
+endif(BUILD_BENCHMARK)
 
-# if(BUILD_DOCUMENTATION)
-#     # find_package(Doxygen)
-#     # if(DOXYGEN_FOUND)
-#     # # set input and output files
-#     # set(DOXYGEN_IN ${CMAKE_CURRENT_SOURCE_DIR}/docs/Doxyfile.in)
-#     # set(DOXYGEN_OUT ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
-#     # # request to configure the file
-#     # configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
-#     # message("Doxygen build started")
-#     # # note the option ALL which allows to build the docs together with the application
-#     # add_custom_target( doc_doxygen ALL
-#     # COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT}
-#     # WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-#     # COMMENT "Generating API documentation with Doxygen"
-#     # VERBATIM )
-#     # else(DOXYGEN_FOUND)
-#     # message("Doxygen need to be installed to generate the documentation")
-#     # endif(DOXYGEN_FOUND)
-# endif(BUILD_DOCUMENTATION)
+if(BUILD_DOCUMENTATION)
+    # find_package(Doxygen)
+    # if(DOXYGEN_FOUND)
+    # # set input and output files
+    # set(DOXYGEN_IN ${CMAKE_CURRENT_SOURCE_DIR}/docs/Doxyfile.in)
+    # set(DOXYGEN_OUT ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
+    # # request to configure the file
+    # configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
+    # message("Doxygen build started")
+    # # note the option ALL which allows to build the docs together with the application
+    # add_custom_target( doc_doxygen ALL
+    # COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT}
+    # WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    # COMMENT "Generating API documentation with Doxygen"
+    # VERBATIM )
+    # else(DOXYGEN_FOUND)
+    # message("Doxygen need to be installed to generate the documentation")
+    # endif(DOXYGEN_FOUND)
+endif(BUILD_DOCUMENTATION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,33 +23,33 @@ endif()
 add_subdirectory(${THIRDPARTY_DIR})
 add_subdirectory(${LIBRARY_DIR})
 
-# Build and run tests
-if(BUILD_TESTING)
-    include(CTest)
-    add_subdirectory(${PROJECT_SOURCE_DIR}/tests)
-endif(BUILD_TESTING)
+# # Build and run tests
+# if(BUILD_TESTING)
+#     include(CTest)
+#     add_subdirectory(${PROJECT_SOURCE_DIR}/tests)
+# endif(BUILD_TESTING)
 
-# Build and run benchmark
-if(BUILD_BENCHMARK)
-    add_subdirectory(benchmark)
-endif(BUILD_BENCHMARK)
+# # Build and run benchmark
+# if(BUILD_BENCHMARK)
+#     add_subdirectory(benchmark)
+# endif(BUILD_BENCHMARK)
 
-if(BUILD_DOCUMENTATION)
-    # find_package(Doxygen)
-    # if(DOXYGEN_FOUND)
-    # # set input and output files
-    # set(DOXYGEN_IN ${CMAKE_CURRENT_SOURCE_DIR}/docs/Doxyfile.in)
-    # set(DOXYGEN_OUT ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
-    # # request to configure the file
-    # configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
-    # message("Doxygen build started")
-    # # note the option ALL which allows to build the docs together with the application
-    # add_custom_target( doc_doxygen ALL
-    # COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT}
-    # WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    # COMMENT "Generating API documentation with Doxygen"
-    # VERBATIM )
-    # else(DOXYGEN_FOUND)
-    # message("Doxygen need to be installed to generate the documentation")
-    # endif(DOXYGEN_FOUND)
-endif(BUILD_DOCUMENTATION)
+# if(BUILD_DOCUMENTATION)
+#     # find_package(Doxygen)
+#     # if(DOXYGEN_FOUND)
+#     # # set input and output files
+#     # set(DOXYGEN_IN ${CMAKE_CURRENT_SOURCE_DIR}/docs/Doxyfile.in)
+#     # set(DOXYGEN_OUT ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
+#     # # request to configure the file
+#     # configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
+#     # message("Doxygen build started")
+#     # # note the option ALL which allows to build the docs together with the application
+#     # add_custom_target( doc_doxygen ALL
+#     # COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT}
+#     # WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+#     # COMMENT "Generating API documentation with Doxygen"
+#     # VERBATIM )
+#     # else(DOXYGEN_FOUND)
+#     # message("Doxygen need to be installed to generate the documentation")
+#     # endif(DOXYGEN_FOUND)
+# endif(BUILD_DOCUMENTATION)

--- a/clic/CMakeLists.txt
+++ b/clic/CMakeLists.txt
@@ -14,6 +14,9 @@ file(GLOB_RECURSE OPENCL_FILE_H ${OpenCL_HEADERS_DIR}/*.h)
 file(GLOB_RECURSE OPENCL_FILE_HPP ${OpenCL_CLHPP_DIR}/*.hpp)
 list(APPEND OPENCL_FILE ${OPENCL_FILE_H} ${OPENCL_FILE_HPP})
 
+# message(STATUS ${OPENCL_FILE_H}) 
+# message(STATUS ${OPENCL_FILE_HPP})
+
 # define library target
 add_library(${LIBRARY_NAME} ${SOURCES_FILES})
 

--- a/clic/CMakeLists.txt
+++ b/clic/CMakeLists.txt
@@ -1,3 +1,16 @@
+ExternalProject_Get_Property(OpenCL_HEADERS SOURCE_DIR)
+message(STATUS "git opencl header dir: ${SOURCE_DIR}")
+set(OpenCL_HEADERS_DIR "${CMAKE_CURRENT_BINARY_DIR}/OpenCL_headers/" CACHE PATH "Path to opencl headers" FORCE)
+
+ExternalProject_Get_Property(OpenCL_CLHPP SOURCE_DIR)
+message(STATUS "git opencl header dir: ${SOURCE_DIR}")
+set(OpenCL_CLHPP_DIR "${CMAKE_CURRENT_BINARY_DIR}/OpenCL_clhpp/include/" CACHE PATH "Path to opencl clhpp" FORCE)
+
+set(OpenCL_INCLUDE_DIR ${OpenCL_HEADERS_DIR} ${OpenCL_CLHPP_DIR} CACHE PATH "Path to opencl (header and clhpp)" FORCE)
+
+message(STATUS "git opencl includes: ${OpenCL_INCLUDE_DIR}")
+
+
 # Create and configure 'clic.h'
 # - define OpenCL version and includes
 # - define CLIC version

--- a/clic/CMakeLists.txt
+++ b/clic/CMakeLists.txt
@@ -1,18 +1,17 @@
-ExternalProject_Get_Property(OpenCL_HEADERS SOURCE_DIR)
-message(STATUS "git opencl header dir: ${SOURCE_DIR}")
-set(OpenCL_HEADERS_DIR "${CMAKE_CURRENT_BINARY_DIR}/OpenCL_headers/" CACHE PATH "Path to opencl headers" FORCE)
+# ExternalProject_Get_Property(OpenCL_HEADERS SOURCE_DIR)
+# message(STATUS "git opencl header dir: ${SOURCE_DIR}")
+# set(OpenCL_HEADERS_DIR "${CMAKE_CURRENT_BINARY_DIR}/OpenCL_headers/" CACHE PATH "Path to opencl headers" FORCE)
 
-ExternalProject_Get_Property(OpenCL_CLHPP SOURCE_DIR)
-message(STATUS "git opencl header dir: ${SOURCE_DIR}")
-set(OpenCL_CLHPP_DIR "${CMAKE_CURRENT_BINARY_DIR}/OpenCL_clhpp/include/" CACHE PATH "Path to opencl clhpp" FORCE)
+# ExternalProject_Get_Property(OpenCL_CLHPP SOURCE_DIR)
+# message(STATUS "git opencl header dir: ${SOURCE_DIR}")
+# set(OpenCL_CLHPP_DIR "${CMAKE_CURRENT_BINARY_DIR}/OpenCL_clhpp/include/" CACHE PATH "Path to opencl clhpp" FORCE)
 
-set(OpenCL_INCLUDE_DIR ${OpenCL_HEADERS_DIR} ${OpenCL_CLHPP_DIR} CACHE PATH "Path to opencl (header and clhpp)" FORCE)
+# # set(OpenCL_INCLUDE_DIR ${OpenCL_HEADERS_DIR} ${OpenCL_CLHPP_DIR} CACHE PATH "Path to opencl (header and clhpp)" FORCE)
 
-message(STATUS "git opencl includes: ${OpenCL_INCLUDE_DIR}")
+# # message(STATUS "git opencl includes: ${OpenCL_INCLUDE_DIR}")
 
 
 # Create and configure 'clic.h'
-# - define OpenCL version and includes
 # - define CLIC version
 configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME_LOWERCASE}.hpp.in"
@@ -20,11 +19,11 @@ configure_file(
     NO_SOURCE_PERMISSIONS @ONLY
 )
 
-# fetch sources (.cpp) and public headers (.hpp)
+# # fetch sources (.cpp) and public headers (.hpp)
 file(GLOB_RECURSE SOURCES_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 file(GLOB_RECURSE HEADERS_FILE ${CMAKE_CURRENT_SOURCE_DIR}/include/core/*.hpp)
-file(GLOB_RECURSE OPENCL_FILE_H ${OpenCL_HEADERS_DIR}/*.h)
-file(GLOB_RECURSE OPENCL_FILE_HPP ${OpenCL_CLHPP_DIR}/*.hpp)
+file(GLOB_RECURSE OPENCL_FILE_H ${OpenCL_HEADERS_SRC_DIR}/*.h)
+file(GLOB_RECURSE OPENCL_FILE_HPP ${OpenCL_CLHPP_SRC_DIR}/*.hpp)
 list(APPEND OPENCL_FILE ${OPENCL_FILE_H} ${OPENCL_FILE_HPP})
 
 # message(STATUS ${OPENCL_FILE_H}) 
@@ -50,7 +49,7 @@ target_compile_definitions(${LIBRARY_NAME} PUBLIC "${PROJECT_NAME_UPPERCASE}_DEB
 target_compile_features(${LIBRARY_NAME} PUBLIC cxx_std_17)
 
 # Target dependencies
-add_dependencies(${LIBRARY_NAME} generate_kernels_list generate_kernels OpenCL_HEADERS OpenCL_CLHPP)
+add_dependencies(${LIBRARY_NAME} generate_kernels_list generate_kernels)
 
 add_custom_target(
     generate_kernels 
@@ -85,8 +84,8 @@ list(APPEND INCLUDE_DIR_LIST ${CMAKE_CURRENT_BINARY_DIR}/include)
 # - header location in project: ${CMAKE_CURRENT_BINARY_DIR}/generated_headers
 target_include_directories(${LIBRARY_NAME} PUBLIC
     "$<BUILD_INTERFACE:${INCLUDE_DIR_LIST}>"
-    "$<BUILD_INTERFACE:${OpenCL_HEADERS_DIR}>"
-    "$<BUILD_INTERFACE:${OpenCL_CLHPP_DIR}>"
+    "$<BUILD_INTERFACE:${OpenCL_HEADERS_SRC_DIR}>"
+    "$<BUILD_INTERFACE:${OpenCL_CLHPP_SRC_DIR}>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/${PROJECT_NAME}>"
 )
 

--- a/clic/CMakeLists.txt
+++ b/clic/CMakeLists.txt
@@ -26,8 +26,7 @@ file(GLOB_RECURSE OPENCL_FILE_H ${OpenCL_HEADERS_SRC_DIR}/*.h)
 file(GLOB_RECURSE OPENCL_FILE_HPP ${OpenCL_CLHPP_SRC_DIR}/*.hpp)
 list(APPEND OPENCL_FILE ${OPENCL_FILE_H} ${OPENCL_FILE_HPP})
 
-# message(STATUS ${OPENCL_FILE_H}) 
-# message(STATUS ${OPENCL_FILE_HPP})
+message(STATUS ${OPENCL_FILE}) 
 
 # define library target
 add_library(${LIBRARY_NAME} ${SOURCES_FILES})
@@ -84,8 +83,7 @@ list(APPEND INCLUDE_DIR_LIST ${CMAKE_CURRENT_BINARY_DIR}/include)
 # - header location in project: ${CMAKE_CURRENT_BINARY_DIR}/generated_headers
 target_include_directories(${LIBRARY_NAME} PUBLIC
     "$<BUILD_INTERFACE:${INCLUDE_DIR_LIST}>"
-    "$<BUILD_INTERFACE:${OpenCL_HEADERS_SRC_DIR}>"
-    "$<BUILD_INTERFACE:${OpenCL_CLHPP_SRC_DIR}>"
+    "$<BUILD_INTERFACE:${OpenCL_INCLUDE_DIR}>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/${PROJECT_NAME}>"
 )
 

--- a/clic/CMakeLists.txt
+++ b/clic/CMakeLists.txt
@@ -1,16 +1,3 @@
-# ExternalProject_Get_Property(OpenCL_HEADERS SOURCE_DIR)
-# message(STATUS "git opencl header dir: ${SOURCE_DIR}")
-# set(OpenCL_HEADERS_DIR "${CMAKE_CURRENT_BINARY_DIR}/OpenCL_headers/" CACHE PATH "Path to opencl headers" FORCE)
-
-# ExternalProject_Get_Property(OpenCL_CLHPP SOURCE_DIR)
-# message(STATUS "git opencl header dir: ${SOURCE_DIR}")
-# set(OpenCL_CLHPP_DIR "${CMAKE_CURRENT_BINARY_DIR}/OpenCL_clhpp/include/" CACHE PATH "Path to opencl clhpp" FORCE)
-
-# # set(OpenCL_INCLUDE_DIR ${OpenCL_HEADERS_DIR} ${OpenCL_CLHPP_DIR} CACHE PATH "Path to opencl (header and clhpp)" FORCE)
-
-# # message(STATUS "git opencl includes: ${OpenCL_INCLUDE_DIR}")
-
-
 # Create and configure 'clic.h'
 # - define CLIC version
 configure_file(
@@ -25,8 +12,6 @@ file(GLOB_RECURSE HEADERS_FILE ${CMAKE_CURRENT_SOURCE_DIR}/include/core/*.hpp)
 file(GLOB_RECURSE OPENCL_FILE_H ${OpenCL_HEADERS_SRC_DIR}/*.h)
 file(GLOB_RECURSE OPENCL_FILE_HPP ${OpenCL_CLHPP_SRC_DIR}/*.hpp)
 list(APPEND OPENCL_FILE ${OPENCL_FILE_H} ${OPENCL_FILE_HPP})
-
-message(STATUS ${OPENCL_FILE}) 
 
 # define library target
 add_library(${LIBRARY_NAME} ${SOURCES_FILES})

--- a/clic/CMakeLists.txt
+++ b/clic/CMakeLists.txt
@@ -50,7 +50,7 @@ target_compile_definitions(${LIBRARY_NAME} PUBLIC "${PROJECT_NAME_UPPERCASE}_DEB
 target_compile_features(${LIBRARY_NAME} PUBLIC cxx_std_17)
 
 # Target dependencies
-add_dependencies(${LIBRARY_NAME} generate_kernels_list generate_kernels)
+add_dependencies(${LIBRARY_NAME} generate_kernels_list generate_kernels OpenCL_HEADERS OpenCL_CLHPP)
 
 add_custom_target(
     generate_kernels 

--- a/clic/CMakeLists.txt
+++ b/clic/CMakeLists.txt
@@ -72,7 +72,8 @@ list(APPEND INCLUDE_DIR_LIST ${CMAKE_CURRENT_BINARY_DIR}/include)
 # - header location in project: ${CMAKE_CURRENT_BINARY_DIR}/generated_headers
 target_include_directories(${LIBRARY_NAME} PUBLIC
     "$<BUILD_INTERFACE:${INCLUDE_DIR_LIST}>"
-    "$<BUILD_INTERFACE:${OpenCL_INCLUDE_DIR}>"
+    "$<BUILD_INTERFACE:${OpenCL_HEADERS_DIR}>"
+    "$<BUILD_INTERFACE:${OpenCL_CLHPP_DIR}>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/${PROJECT_NAME}>"
 )
 

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -42,6 +42,7 @@ endif()
 
 set(OpenCL_HEADERS_SRC_DIR ${CMAKE_BINARY_DIR}/_deps/opencl_headers-src CACHE PATH "Path to opencl headers" FORCE)
 set(OpenCL_CLHPP_SRC_DIR ${CMAKE_BINARY_DIR}/_deps/opencl_clhpp-src CACHE PATH "Path to opencl clhpp" FORCE)
+set(OpenCL_INCLUDE_DIR ${OpenCL_HEADERS_SRC_DIR} ${OpenCL_CLHPP_SRC_DIR} CACHE PATH "Path to opencl (header and clhpp)" FORCE)
 
 message(STATUS "git opencl header src dir: ${OpenCL_HEADERS_SRC_DIR}")
 message(STATUS "git opencl clhpp src dir: ${OpenCL_CLHPP_SRC_DIR}")

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -33,7 +33,6 @@ endif()
 
 set(OpenCL_HEADERS_SRC_DIR ${CMAKE_CURRENT_BINARY_DIR}/opencl_headers-src CACHE PATH "Path to opencl headers" FORCE)
 set(OpenCL_CLHPP_SRC_DIR ${CMAKE_CURRENT_BINARY_DIR}/opencl_clhpp-src CACHE PATH "Path to opencl clhpp" FORCE)
-# set(OpenCL_INCLUDE_DIR ${OpenCL_HEADERS_SRC_DIR} ${OpenCL_CLHPP_SRC_DIR} CACHE PATH "Path to opencl (header and clhpp)" FORCE)
 set(OpenCL_INCLUDE_DIR ${OpenCL_HEADERS_SRC_DIR} ${OpenCL_CLHPP_SRC_DIR}/include/ CACHE PATH "Path to opencl (header and clhpp)" FORCE)
 
 ## Set OpenCL version to 1.2

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -26,17 +26,17 @@ ExternalProject_Add(OpenCL_CLHPP
     CONFIGURE_COMMAND ""
 )
 
-ExternalProject_Get_Property(OpenCL_HEADERS SOURCE_DIR)
-message(STATUS "git opencl header dir: ${SOURCE_DIR}")
-set(OpenCL_HEADERS_DIR "${CMAKE_CURRENT_BINARY_DIR}/OpenCL_headers/" CACHE PATH "Path to opencl headers" FORCE)
+# ExternalProject_Get_Property(OpenCL_HEADERS SOURCE_DIR)
+# message(STATUS "git opencl header dir: ${SOURCE_DIR}")
+# set(OpenCL_HEADERS_DIR "${CMAKE_CURRENT_BINARY_DIR}/OpenCL_headers/" CACHE PATH "Path to opencl headers" FORCE)
 
-ExternalProject_Get_Property(OpenCL_CLHPP SOURCE_DIR)
-message(STATUS "git opencl header dir: ${SOURCE_DIR}")
-set(OpenCL_CLHPP_DIR "${CMAKE_CURRENT_BINARY_DIR}/OpenCL_clhpp/include/" CACHE PATH "Path to opencl clhpp" FORCE)
+# ExternalProject_Get_Property(OpenCL_CLHPP SOURCE_DIR)
+# message(STATUS "git opencl header dir: ${SOURCE_DIR}")
+# set(OpenCL_CLHPP_DIR "${CMAKE_CURRENT_BINARY_DIR}/OpenCL_clhpp/include/" CACHE PATH "Path to opencl clhpp" FORCE)
 
-set(OpenCL_INCLUDE_DIR ${OpenCL_HEADERS_DIR} ${OpenCL_CLHPP_DIR} CACHE PATH "Path to opencl (header and clhpp)" FORCE)
+# set(OpenCL_INCLUDE_DIR ${OpenCL_HEADERS_DIR} ${OpenCL_CLHPP_DIR} CACHE PATH "Path to opencl (header and clhpp)" FORCE)
 
-message(STATUS "git opencl includes: ${OpenCL_INCLUDE_DIR}")
+# message(STATUS "git opencl includes: ${OpenCL_INCLUDE_DIR}")
 
 # set(OpenCL_VERSION "${OpenCL_VERSION_MAJOR}${OpenCL_VERSION_MINOR}0" CACHE STRING "OpenCL version" FORCE)
 set(OpenCL_VERSION "120" CACHE STRING "OpenCL version" FORCE)

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -1,37 +1,25 @@
+
+## Manage OpenCL Kernels source code
 # define path dir to kernel and preamble from clesperanto kernel git repo.
 set(OCL_KERNELS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/clesperanto-kernels CACHE PATH "Path to opencl kernel files (.cl)" FORCE)
 mark_as_advanced(OCL_KERNELS_DIR)
 
-# set(OpenCL_HEADERS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/opencl/ocl-headers/" CACHE PATH "Path to opencl headers" FORCE)
-# set(OpenCL_CLHPP_DIR "${CMAKE_CURRENT_SOURCE_DIR}/opencl/ocl-clhpp/include/" CACHE PATH "Path to opencl clhpp" FORCE)
-# set(OpenCL_INCLUDE_DIR ${OpenCL_HEADERS_DIR} ${OpenCL_CLHPP_DIR} CACHE PATH "Path to opencl (header and clhpp)" FORCE)
+
+## Manage OpenCL headers source code
 
 include(FetchContent)
-# include(ExternalProject)
-
 FetchContent_Declare(OpenCL_HEADERS
     GIT_REPOSITORY https://github.com/KhronosGroup/OpenCL-Headers.git
     GIT_TAG v2022.09.30
     CONFIGURE_COMMAND ""
     BUILD_ALWAYS OFF
-    )
-    
+    ) 
 FetchContent_Declare(OpenCL_CLHPP
     GIT_REPOSITORY https://github.com/KhronosGroup/OpenCL-CLHPP.git
     GIT_TAG v2022.09.30
     CONFIGURE_COMMAND ""
     BUILD_ALWAYS OFF
     )
-
-# if(NOT OpenCL_HEADERS_POPULATED)
-#     FetchContent_MakeAvailable(OpenCL_HEADERS)
-# endif()
-# if(NOT OpenCL_CLHPP_POPULATED)
-#     FetchContent_MakeAvailable(OpenCL_CLHPP)
-# endif()
-
-# FetchContent_GetProperties(OpenCL_HEADERS)
-# FetchContent_GetProperties(OpenCL_CLHPP)
 
 if(NOT OpenCL_HEADERS_POPULATED)
     FetchContent_Populate(OpenCL_HEADERS)
@@ -42,42 +30,9 @@ endif()
 
 set(OpenCL_HEADERS_SRC_DIR ${CMAKE_BINARY_DIR}/_deps/opencl_headers-src CACHE PATH "Path to opencl headers" FORCE)
 set(OpenCL_CLHPP_SRC_DIR ${CMAKE_BINARY_DIR}/_deps/opencl_clhpp-src CACHE PATH "Path to opencl clhpp" FORCE)
-set(OpenCL_INCLUDE_DIR ${OpenCL_HEADERS_SRC_DIR} ${OpenCL_CLHPP_SRC_DIR} CACHE PATH "Path to opencl (header and clhpp)" FORCE)
-
-message(STATUS "git opencl header src dir: ${OpenCL_HEADERS_SRC_DIR}")
-message(STATUS "git opencl clhpp src dir: ${OpenCL_CLHPP_SRC_DIR}")
-
-
-# ExternalProject_Add(OpenCL_HEADERS
-#     SOURCE_DIR ${OpenCL_HEADERS_SRC_DIR}
-#     BUILD_ALWAYS OFF
-#     INSTALL_COMMAND ""
-#     CONFIGURE_COMMAND ""
-# )
-
-# ExternalProject_Add(OpenCL_CLHPP
-#     SOURCE_DIR ${OpenCL_CLHPP_SRC_DIR}
-#     BUILD_ALWAYS OFF
-#     INSTALL_COMMAND ""
-#     CONFIGURE_COMMAND ""
-# )
-
-# FetchContent_GetProperties(OpenCL_HEADERS SOURCE_DIR)
-# message(STATUS "git opencl header dir: ${SOURCE_DIR}")
-
-# FetchContent_GetProperties(OpenCL_CLHPP SOURCE_DIR)
-# message(STATUS "git opencl header dir: ${SOURCE_DIR}")
-
-# ExternalProject_Get_Property(OpenCL_HEADERS SOURCE_DIR)
-# message(STATUS "git opencl header dir: ${SOURCE_DIR}")
-# set(OpenCL_HEADERS_DIR "${CMAKE_CURRENT_BINARY_DIR}/OpenCL_headers/" CACHE PATH "Path to opencl headers" FORCE)
-
-# ExternalProject_Get_Property(OpenCL_CLHPP SOURCE_DIR)
-# message(STATUS "git opencl header dir: ${SOURCE_DIR}")
-# set(OpenCL_CLHPP_DIR "${CMAKE_CURRENT_BINARY_DIR}/OpenCL_clhpp/include/" CACHE PATH "Path to opencl clhpp" FORCE)
-
+# set(OpenCL_INCLUDE_DIR ${OpenCL_HEADERS_SRC_DIR} ${OpenCL_CLHPP_SRC_DIR} CACHE PATH "Path to opencl (header and clhpp)" FORCE)
 set(OpenCL_INCLUDE_DIR ${OpenCL_HEADERS_SRC_DIR} ${OpenCL_CLHPP_SRC_DIR}/include/ CACHE PATH "Path to opencl (header and clhpp)" FORCE)
-message(STATUS "git opencl includes: ${OpenCL_INCLUDE_DIR}")
 
+## Set OpenCL version to 1.2
 # set(OpenCL_VERSION "${OpenCL_VERSION_MAJOR}${OpenCL_VERSION_MINOR}0" CACHE STRING "OpenCL version" FORCE)
 set(OpenCL_VERSION "120" CACHE STRING "OpenCL version" FORCE)

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -26,13 +26,17 @@ ExternalProject_Add(OpenCL_CLHPP
     CONFIGURE_COMMAND ""
 )
 
+ExternalProject_Get_Property(OpenCL_HEADERS SOURCE_DIR)
+message(STATUS "git opencl header dir: ${SOURCE_DIR}")
 set(OpenCL_HEADERS_DIR "${CMAKE_CURRENT_BINARY_DIR}/OpenCL_headers/" CACHE PATH "Path to opencl headers" FORCE)
+
+ExternalProject_Get_Property(OpenCL_CLHPP SOURCE_DIR)
+message(STATUS "git opencl header dir: ${SOURCE_DIR}")
 set(OpenCL_CLHPP_DIR "${CMAKE_CURRENT_BINARY_DIR}/OpenCL_clhpp/include/" CACHE PATH "Path to opencl clhpp" FORCE)
+
 set(OpenCL_INCLUDE_DIR ${OpenCL_HEADERS_DIR} ${OpenCL_CLHPP_DIR} CACHE PATH "Path to opencl (header and clhpp)" FORCE)
 
-# message(STATUS "git opencl header dir: ${OpenCL_HEADERS_DIR}")
-# message(STATUS "git opencl clhpp dir: ${OpenCL_CLHPP_DIR}")
-# message(STATUS "git opencl includes: ${OpenCL_INCLUDE_DIR}")
+message(STATUS "git opencl includes: ${OpenCL_INCLUDE_DIR}")
 
 # set(OpenCL_VERSION "${OpenCL_VERSION_MAJOR}${OpenCL_VERSION_MINOR}0" CACHE STRING "OpenCL version" FORCE)
 set(OpenCL_VERSION "120" CACHE STRING "OpenCL version" FORCE)

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -2,12 +2,9 @@
 set(OCL_KERNELS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/clesperanto-kernels CACHE PATH "Path to opencl kernel files (.cl)" FORCE)
 mark_as_advanced(OCL_KERNELS_DIR)
 
-set(OpenCL_HEADERS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/opencl/ocl-headers/" CACHE PATH "Path to opencl headers" FORCE)
-set(OpenCL_CLHPP_DIR "${CMAKE_CURRENT_SOURCE_DIR}/opencl/ocl-clhpp/include/" CACHE PATH "Path to opencl clhpp" FORCE)
-set(OpenCL_INCLUDE_DIR ${OpenCL_HEADERS_DIR} ${OpenCL_CLHPP_DIR} CACHE PATH "Path to opencl (header and clhpp)" FORCE)
-
-# set(OpenCL_VERSION "${OpenCL_VERSION_MAJOR}${OpenCL_VERSION_MINOR}0" CACHE STRING "OpenCL version" FORCE)
-set(OpenCL_VERSION "120" CACHE STRING "OpenCL version" FORCE)
+# set(OpenCL_HEADERS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/opencl/ocl-headers/" CACHE PATH "Path to opencl headers" FORCE)
+# set(OpenCL_CLHPP_DIR "${CMAKE_CURRENT_SOURCE_DIR}/opencl/ocl-clhpp/include/" CACHE PATH "Path to opencl clhpp" FORCE)
+# set(OpenCL_INCLUDE_DIR ${OpenCL_HEADERS_DIR} ${OpenCL_CLHPP_DIR} CACHE PATH "Path to opencl (header and clhpp)" FORCE)
 
 include(ExternalProject)
 
@@ -29,6 +26,13 @@ ExternalProject_Add(OpenCL_CLHPP
     CONFIGURE_COMMAND ""
 )
 
-message(STATUS "git opencl header dir: ${CMAKE_CURRENT_BINARY_DIR}/OpenCL_headers")
-message(STATUS "git opencl clhpp dir: ${CMAKE_CURRENT_BINARY_DIR}/OpenCL_clhpp")
+set(OpenCL_HEADERS_DIR "${CMAKE_CURRENT_BINARY_DIR}/OpenCL_headers/" CACHE PATH "Path to opencl headers" FORCE)
+set(OpenCL_CLHPP_DIR "${CMAKE_CURRENT_BINARY_DIR}/OpenCL_clhpp/include/" CACHE PATH "Path to opencl clhpp" FORCE)
+set(OpenCL_INCLUDE_DIR ${OpenCL_HEADERS_DIR} ${OpenCL_CLHPP_DIR} CACHE PATH "Path to opencl (header and clhpp)" FORCE)
 
+# message(STATUS "git opencl header dir: ${OpenCL_HEADERS_DIR}")
+# message(STATUS "git opencl clhpp dir: ${OpenCL_CLHPP_DIR}")
+# message(STATUS "git opencl includes: ${OpenCL_INCLUDE_DIR}")
+
+# set(OpenCL_VERSION "${OpenCL_VERSION_MAJOR}${OpenCL_VERSION_MINOR}0" CACHE STRING "OpenCL version" FORCE)
+set(OpenCL_VERSION "120" CACHE STRING "OpenCL version" FORCE)

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -6,14 +6,16 @@ mark_as_advanced(OCL_KERNELS_DIR)
 
 
 ## Manage OpenCL headers source code
-
 include(FetchContent)
+set(FETCHCONTENT_BASE_DIR ${CMAKE_CURRENT_BINARY_DIR})
+
 FetchContent_Declare(OpenCL_HEADERS
     GIT_REPOSITORY https://github.com/KhronosGroup/OpenCL-Headers.git
     GIT_TAG v2022.09.30
     CONFIGURE_COMMAND ""
     BUILD_ALWAYS OFF
     ) 
+
 FetchContent_Declare(OpenCL_CLHPP
     GIT_REPOSITORY https://github.com/KhronosGroup/OpenCL-CLHPP.git
     GIT_TAG v2022.09.30
@@ -24,6 +26,7 @@ FetchContent_Declare(OpenCL_CLHPP
 if(NOT OpenCL_HEADERS_POPULATED)
     FetchContent_Populate(OpenCL_HEADERS)
 endif()
+
 if(NOT OpenCL_CLHPP_POPULATED)
     FetchContent_Populate(OpenCL_CLHPP)
 endif()

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -31,8 +31,8 @@ if(NOT OpenCL_CLHPP_POPULATED)
     FetchContent_Populate(OpenCL_CLHPP)
 endif()
 
-set(OpenCL_HEADERS_SRC_DIR ${CMAKE_BINARY_DIR}/_deps/opencl_headers-src CACHE PATH "Path to opencl headers" FORCE)
-set(OpenCL_CLHPP_SRC_DIR ${CMAKE_BINARY_DIR}/_deps/opencl_clhpp-src CACHE PATH "Path to opencl clhpp" FORCE)
+set(OpenCL_HEADERS_SRC_DIR ${CMAKE_CURRENT_BINARY_DIR}/opencl_headers-src CACHE PATH "Path to opencl headers" FORCE)
+set(OpenCL_CLHPP_SRC_DIR ${CMAKE_CURRENT_BINARY_DIR}/opencl_clhpp-src CACHE PATH "Path to opencl clhpp" FORCE)
 # set(OpenCL_INCLUDE_DIR ${OpenCL_HEADERS_SRC_DIR} ${OpenCL_CLHPP_SRC_DIR} CACHE PATH "Path to opencl (header and clhpp)" FORCE)
 set(OpenCL_INCLUDE_DIR ${OpenCL_HEADERS_SRC_DIR} ${OpenCL_CLHPP_SRC_DIR}/include/ CACHE PATH "Path to opencl (header and clhpp)" FORCE)
 

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -6,25 +6,66 @@ mark_as_advanced(OCL_KERNELS_DIR)
 # set(OpenCL_CLHPP_DIR "${CMAKE_CURRENT_SOURCE_DIR}/opencl/ocl-clhpp/include/" CACHE PATH "Path to opencl clhpp" FORCE)
 # set(OpenCL_INCLUDE_DIR ${OpenCL_HEADERS_DIR} ${OpenCL_CLHPP_DIR} CACHE PATH "Path to opencl (header and clhpp)" FORCE)
 
-include(ExternalProject)
+include(FetchContent)
+# include(ExternalProject)
 
-ExternalProject_Add(OpenCL_HEADERS
+FetchContent_Declare(OpenCL_HEADERS
     GIT_REPOSITORY https://github.com/KhronosGroup/OpenCL-Headers.git
     GIT_TAG v2022.09.30
-    SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/OpenCL_headers
-    BUILD_COMMAND ""
-    INSTALL_COMMAND ""
     CONFIGURE_COMMAND ""
-)
-
-ExternalProject_Add(OpenCL_CLHPP
+    BUILD_ALWAYS OFF
+    )
+    
+FetchContent_Declare(OpenCL_CLHPP
     GIT_REPOSITORY https://github.com/KhronosGroup/OpenCL-CLHPP.git
     GIT_TAG v2022.09.30
-    SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/OpenCL_clhpp
-    BUILD_COMMAND ""
-    INSTALL_COMMAND ""
     CONFIGURE_COMMAND ""
-)
+    BUILD_ALWAYS OFF
+    )
+
+# if(NOT OpenCL_HEADERS_POPULATED)
+#     FetchContent_MakeAvailable(OpenCL_HEADERS)
+# endif()
+# if(NOT OpenCL_CLHPP_POPULATED)
+#     FetchContent_MakeAvailable(OpenCL_CLHPP)
+# endif()
+
+# FetchContent_GetProperties(OpenCL_HEADERS)
+# FetchContent_GetProperties(OpenCL_CLHPP)
+
+if(NOT OpenCL_HEADERS_POPULATED)
+    FetchContent_Populate(OpenCL_HEADERS)
+endif()
+if(NOT OpenCL_CLHPP_POPULATED)
+    FetchContent_Populate(OpenCL_CLHPP)
+endif()
+
+set(OpenCL_HEADERS_SRC_DIR ${CMAKE_BINARY_DIR}/_deps/opencl_headers-src CACHE PATH "Path to opencl headers" FORCE)
+set(OpenCL_CLHPP_SRC_DIR ${CMAKE_BINARY_DIR}/_deps/opencl_clhpp-src CACHE PATH "Path to opencl clhpp" FORCE)
+
+message(STATUS "git opencl header src dir: ${OpenCL_HEADERS_SRC_DIR}")
+message(STATUS "git opencl clhpp src dir: ${OpenCL_CLHPP_SRC_DIR}")
+
+
+# ExternalProject_Add(OpenCL_HEADERS
+#     SOURCE_DIR ${OpenCL_HEADERS_SRC_DIR}
+#     BUILD_ALWAYS OFF
+#     INSTALL_COMMAND ""
+#     CONFIGURE_COMMAND ""
+# )
+
+# ExternalProject_Add(OpenCL_CLHPP
+#     SOURCE_DIR ${OpenCL_CLHPP_SRC_DIR}
+#     BUILD_ALWAYS OFF
+#     INSTALL_COMMAND ""
+#     CONFIGURE_COMMAND ""
+# )
+
+# FetchContent_GetProperties(OpenCL_HEADERS SOURCE_DIR)
+# message(STATUS "git opencl header dir: ${SOURCE_DIR}")
+
+# FetchContent_GetProperties(OpenCL_CLHPP SOURCE_DIR)
+# message(STATUS "git opencl header dir: ${SOURCE_DIR}")
 
 # ExternalProject_Get_Property(OpenCL_HEADERS SOURCE_DIR)
 # message(STATUS "git opencl header dir: ${SOURCE_DIR}")
@@ -34,9 +75,8 @@ ExternalProject_Add(OpenCL_CLHPP
 # message(STATUS "git opencl header dir: ${SOURCE_DIR}")
 # set(OpenCL_CLHPP_DIR "${CMAKE_CURRENT_BINARY_DIR}/OpenCL_clhpp/include/" CACHE PATH "Path to opencl clhpp" FORCE)
 
-# set(OpenCL_INCLUDE_DIR ${OpenCL_HEADERS_DIR} ${OpenCL_CLHPP_DIR} CACHE PATH "Path to opencl (header and clhpp)" FORCE)
-
-# message(STATUS "git opencl includes: ${OpenCL_INCLUDE_DIR}")
+set(OpenCL_INCLUDE_DIR ${OpenCL_HEADERS_SRC_DIR} ${OpenCL_CLHPP_SRC_DIR}/include/ CACHE PATH "Path to opencl (header and clhpp)" FORCE)
+message(STATUS "git opencl includes: ${OpenCL_INCLUDE_DIR}")
 
 # set(OpenCL_VERSION "${OpenCL_VERSION_MAJOR}${OpenCL_VERSION_MINOR}0" CACHE STRING "OpenCL version" FORCE)
 set(OpenCL_VERSION "120" CACHE STRING "OpenCL version" FORCE)


### PR DESCRIPTION
Try to avoid relying on outside project repository as submodule.
This means removing both opencl-headers and opencl-clhpp submodule

Replace them by a build-time git clone managed by cmake.