### PR TITLE
Add  map/unmap functionnality

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -36,3 +36,8 @@ add_executable(benchmark_maximum_projections benchmark_maximum_projections.cpp)
 target_compile_features(benchmark_maximum_projections PUBLIC cxx_std_17)
 target_link_libraries(benchmark_maximum_projections benchmark_kernel)
 set_target_properties(benchmark_maximum_projections PROPERTIES FOLDER "Benchmark")
+
+add_executable(benchmark_push_pull benchmark_push_pull.cpp)
+target_compile_features(benchmark_push_pull PUBLIC cxx_std_17)
+target_link_libraries(benchmark_push_pull benchmark_kernel)
+set_target_properties(benchmark_push_pull PROPERTIES FOLDER "Benchmark")

--- a/benchmark/benchmark_push_pull.cpp
+++ b/benchmark/benchmark_push_pull.cpp
@@ -1,0 +1,62 @@
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "clesperanto.hpp"
+
+#include <benchmark_base.cpp>
+
+class PushPullBenchmark : public BenchmarkBase
+{
+protected:
+  cle::Clesperanto      cle;
+  std::vector<float>    inputData;
+  std::array<size_t, 3> dim;
+  auto
+  Setup() -> void override
+  {
+    inputData = std::vector<float>(dataWidth * dataWidth * dataWidth);
+    dim = std::array<size_t, 3>{ { dataWidth, dataWidth, dataWidth } };
+
+    cle.GetDevice()->WaitForKernelToFinish();
+  }
+
+  auto
+  Iteration() -> void override
+  {
+    auto gpuInput = cle.Push<float>(inputData, dim);
+    auto output = cle.Pull<float>(gpuInput);
+  }
+
+  auto
+  Teardown() -> void override
+  {}
+
+public:
+  size_t dataWidth = 0;
+
+  PushPullBenchmark()
+    : cle(cle::Clesperanto())
+  {}
+
+  ~PushPullBenchmark() = default;
+};
+
+auto
+main(int argc, char ** argv) -> int
+{
+  PushPullBenchmark d;
+  d.dataWidth = 1 << 10;
+
+  d.iterationWarmupCount = 5;
+
+  if (argc >= 2)
+  {
+    d.dataWidth = std::stoi(argv[1]);
+    std::cout << "using " << d.dataWidth * d.dataWidth * d.dataWidth * sizeof(float) << " bytes memory" << std::endl;
+  }
+
+  d.Run();
+
+  return 0;
+}

--- a/clic/include/core/cleBackend.hpp
+++ b/clic/include/core/cleBackend.hpp
@@ -360,112 +360,112 @@ EnqueueKernelExecution(const cl::CommandQueue &      queue_pointer,
   }
 }
 
-inline auto
-EnqueueUnmapMemObject(const cl::CommandQueue & queue_pointer, const cl::Memory & memory_pointer, void * ptr) -> void
-{
-  cl_int err = queue_pointer.enqueueUnmapMemObject(memory_pointer, ptr);
-  if (err != CL_SUCCESS)
-  {
-    std::cerr << "Backend error in EnqueueUnmapMemObject: " << GetOpenCLErrorInfo(err) << std::endl;
-  }
-}
+// inline auto
+// EnqueueUnmapMemObject(const cl::CommandQueue & queue_pointer, const cl::Memory & memory_pointer, void * ptr) -> void
+// {
+//   cl_int err = queue_pointer.enqueueUnmapMemObject(memory_pointer, ptr);
+//   if (err != CL_SUCCESS)
+//   {
+//     std::cerr << "Backend error in EnqueueUnmapMemObject: " << GetOpenCLErrorInfo(err) << std::endl;
+//   }
+// }
 
-inline auto
-EnqueueMapImage(const cl::CommandQueue &      queue_pointer,
-                const cl::Memory &            image_pointer,
-                const bool &                  block_flag,
-                const std::array<size_t, 3> & origin,
-                const std::array<size_t, 3> & region) -> void *
-{
-  void * ptr = nullptr;
-  cl_int err = CL_SUCCESS;
-  if (image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE1D)
-  {
-    const cl::Image1D memory(image_pointer.get(), true);
-    ptr = queue_pointer.enqueueMapImage(memory,
-                                        static_cast<cl_bool>(block_flag),
-                                        CL_MAP_READ | CL_MAP_WRITE,
-                                        origin,
-                                        region,
-                                        nullptr,
-                                        nullptr,
-                                        nullptr,
-                                        nullptr,
-                                        &err);
-    if (err != CL_SUCCESS)
-    {
-      std::cerr << "Backend error in EnqueueMapImage 1D: " << GetOpenCLErrorInfo(err) << std::endl;
-    }
-    return ptr;
-  }
-  if (image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE2D)
-  {
-    const cl::Image2D memory(image_pointer.get(), true);
-    ptr = queue_pointer.enqueueMapImage(memory,
-                                        static_cast<cl_bool>(block_flag),
-                                        CL_MAP_READ | CL_MAP_WRITE,
-                                        origin,
-                                        region,
-                                        nullptr,
-                                        nullptr,
-                                        nullptr,
-                                        nullptr,
-                                        &err);
-    if (err != CL_SUCCESS)
-    {
-      std::cerr << "Backend error in EnqueueMapImage 2D: " << GetOpenCLErrorInfo(err) << std::endl;
-    }
-    return ptr;
-  }
-  if (image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE3D)
-  {
-    const cl::Image3D memory(image_pointer.get(), true);
-    ptr = queue_pointer.enqueueMapImage(memory,
-                                        static_cast<cl_bool>(block_flag),
-                                        CL_MAP_READ | CL_MAP_WRITE,
-                                        origin,
-                                        region,
-                                        nullptr,
-                                        nullptr,
-                                        nullptr,
-                                        nullptr,
-                                        &err);
-    if (err != CL_SUCCESS)
-    {
-      std::cerr << "Backend error in EnqueueMapImage 3D: " << GetOpenCLErrorInfo(err) << std::endl;
-    }
-    return ptr;
-  }
-  if (err != CL_SUCCESS)
-  {
-    std::cerr << "Backend error in EnqueueMapImage: " << GetOpenCLErrorInfo(err) << std::endl;
-  }
-  return ptr;
-}
+// inline auto
+// EnqueueMapImage(const cl::CommandQueue &      queue_pointer,
+//                 const cl::Memory &            image_pointer,
+//                 const bool &                  block_flag,
+//                 const std::array<size_t, 3> & origin,
+//                 const std::array<size_t, 3> & region) -> void *
+// {
+//   void * ptr = nullptr;
+//   cl_int err = CL_SUCCESS;
+//   if (image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE1D)
+//   {
+//     const cl::Image1D memory(image_pointer.get(), true);
+//     ptr = queue_pointer.enqueueMapImage(memory,
+//                                         static_cast<cl_bool>(block_flag),
+//                                         CL_MAP_READ | CL_MAP_WRITE,
+//                                         origin,
+//                                         region,
+//                                         nullptr,
+//                                         nullptr,
+//                                         nullptr,
+//                                         nullptr,
+//                                         &err);
+//     if (err != CL_SUCCESS)
+//     {
+//       std::cerr << "Backend error in EnqueueMapImage 1D: " << GetOpenCLErrorInfo(err) << std::endl;
+//     }
+//     return ptr;
+//   }
+//   if (image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE2D)
+//   {
+//     const cl::Image2D memory(image_pointer.get(), true);
+//     ptr = queue_pointer.enqueueMapImage(memory,
+//                                         static_cast<cl_bool>(block_flag),
+//                                         CL_MAP_READ | CL_MAP_WRITE,
+//                                         origin,
+//                                         region,
+//                                         nullptr,
+//                                         nullptr,
+//                                         nullptr,
+//                                         nullptr,
+//                                         &err);
+//     if (err != CL_SUCCESS)
+//     {
+//       std::cerr << "Backend error in EnqueueMapImage 2D: " << GetOpenCLErrorInfo(err) << std::endl;
+//     }
+//     return ptr;
+//   }
+//   if (image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE3D)
+//   {
+//     const cl::Image3D memory(image_pointer.get(), true);
+//     ptr = queue_pointer.enqueueMapImage(memory,
+//                                         static_cast<cl_bool>(block_flag),
+//                                         CL_MAP_READ | CL_MAP_WRITE,
+//                                         origin,
+//                                         region,
+//                                         nullptr,
+//                                         nullptr,
+//                                         nullptr,
+//                                         nullptr,
+//                                         &err);
+//     if (err != CL_SUCCESS)
+//     {
+//       std::cerr << "Backend error in EnqueueMapImage 3D: " << GetOpenCLErrorInfo(err) << std::endl;
+//     }
+//     return ptr;
+//   }
+//   if (err != CL_SUCCESS)
+//   {
+//     std::cerr << "Backend error in EnqueueMapImage: " << GetOpenCLErrorInfo(err) << std::endl;
+//   }
+//   return ptr;
+// }
 
-inline auto
-EnqueueMapBuffer(const cl::CommandQueue & queue_pointer,
-                 const cl::Memory &       buffer_pointer,
-                 const bool &             block_flag,
-                 const size_t &           offset,
-                 const size_t &           length_in_bytes) -> void *
-{
-  const cl::Buffer memory(buffer_pointer.get(), true);
-  cl_int           err = CL_SUCCESS;
-  void *           ptr = queue_pointer.enqueueMapBuffer(memory,
-                                              static_cast<cl_bool>(block_flag),
-                                              CL_MAP_READ | CL_MAP_WRITE,
-                                              offset,
-                                              length_in_bytes,
-                                              nullptr,
-                                              nullptr,
-                                              &err);
-  if (err != CL_SUCCESS)
-  {
-    std::cerr << "Backend error in EnqueueMapBuffer: " << GetOpenCLErrorInfo(err) << std::endl;
-  }
-  return ptr;
-}
+// inline auto
+// EnqueueMapBuffer(const cl::CommandQueue & queue_pointer,
+//                  const cl::Memory &       buffer_pointer,
+//                  const bool &             block_flag,
+//                  const size_t &           offset,
+//                  const size_t &           length_in_bytes) -> void *
+// {
+//   const cl::Buffer memory(buffer_pointer.get(), true);
+//   cl_int           err = CL_SUCCESS;
+//   void *           ptr = queue_pointer.enqueueMapBuffer(memory,
+//                                               static_cast<cl_bool>(block_flag),
+//                                               CL_MAP_READ | CL_MAP_WRITE,
+//                                               offset,
+//                                               length_in_bytes,
+//                                               nullptr,
+//                                               nullptr,
+//                                               &err);
+//   if (err != CL_SUCCESS)
+//   {
+//     std::cerr << "Backend error in EnqueueMapBuffer: " << GetOpenCLErrorInfo(err) << std::endl;
+//   }
+//   return ptr;
+// }
 
 inline auto
 EnqueueReadFromBuffer(const cl::CommandQueue & queue_pointer,
@@ -638,34 +638,43 @@ EnqueueCopyBufferToImage(const cl::CommandQueue &      queue_pointer,
 {
   cl_int           err = CL_SUCCESS;
   const cl::Buffer memory(src_buffer_pointer.get(), true);
-  switch (dst_image_pointer.getInfo<CL_MEM_TYPE>())
+
+  if (dst_image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE1D)
   {
-    case CL_MEM_OBJECT_IMAGE1D: {
-      const cl::Image1D dst_memory(dst_image_pointer.get(), true);
-      err = queue_pointer.enqueueCopyBufferToImage(
-        memory, dst_memory, src_offset, dst_origin, dst_region, nullptr, nullptr);
-      break;
+    const cl::Image1D dst_memory(dst_image_pointer.get(), true);
+    err =
+      queue_pointer.enqueueCopyBufferToImage(memory, dst_memory, src_offset, dst_origin, dst_region, nullptr, nullptr);
+    if (err != CL_SUCCESS)
+    {
+      std::cerr << "Backend error in EnqueueCopyBufferToImage 1D : " << GetOpenCLErrorInfo(err) << std::endl;
     }
-    case CL_MEM_OBJECT_IMAGE2D: {
-      const cl::Image2D dst_memory(dst_image_pointer.get(), true);
-      err = queue_pointer.enqueueCopyBufferToImage(
-        memory, dst_memory, src_offset, dst_origin, dst_region, nullptr, nullptr);
-      break;
+    return;
+  }
+  if (dst_image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE2D)
+  {
+    const cl::Image2D dst_memory(dst_image_pointer.get(), true);
+    err =
+      queue_pointer.enqueueCopyBufferToImage(memory, dst_memory, src_offset, dst_origin, dst_region, nullptr, nullptr);
+    if (err != CL_SUCCESS)
+    {
+      std::cerr << "Backend error in EnqueueCopyBufferToImage 2D : " << GetOpenCLErrorInfo(err) << std::endl;
     }
-    case CL_MEM_OBJECT_IMAGE3D: {
-      const cl::Image3D dst_memory(dst_image_pointer.get(), true);
-      err = queue_pointer.enqueueCopyBufferToImage(
-        memory, dst_memory, src_offset, dst_origin, dst_region, nullptr, nullptr);
-      break;
+    return;
+  }
+  if (dst_image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE3D)
+  {
+    const cl::Image3D dst_memory(dst_image_pointer.get(), true);
+    err =
+      queue_pointer.enqueueCopyBufferToImage(memory, dst_memory, src_offset, dst_origin, dst_region, nullptr, nullptr);
+    if (err != CL_SUCCESS)
+    {
+      std::cerr << "Backend error in EnqueueCopyBufferToImage 3D : " << GetOpenCLErrorInfo(err) << std::endl;
     }
+    return;
   }
   if (err != CL_SUCCESS)
   {
     std::cerr << "Backend error in EnqueueCopyBufferToImage : " << GetOpenCLErrorInfo(err) << std::endl;
-  }
-  if (block_flag)
-  {
-    WaitQueueToFinish(queue_pointer);
   }
 }
 
@@ -680,34 +689,44 @@ EnqueueCopyImageToBuffer(const cl::CommandQueue &      queue_pointer,
 {
   cl_int           err = CL_SUCCESS;
   const cl::Buffer dst_memory(dst_buffer_pointer.get(), true);
-  switch (src_image_pointer.getInfo<CL_MEM_TYPE>())
+
+
+  if (src_image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE1D)
   {
-    case CL_MEM_OBJECT_IMAGE1D: {
-      const cl::Image1D memory(src_image_pointer.get(), true);
-      err = queue_pointer.enqueueCopyImageToBuffer(
-        memory, dst_memory, src_origin, src_region, dst_offset, nullptr, nullptr);
-      break;
+    const cl::Image1D src_memory(src_image_pointer.get(), true);
+    err = queue_pointer.enqueueCopyImageToBuffer(
+      src_memory, dst_memory, src_origin, src_region, dst_offset, nullptr, nullptr);
+    if (err != CL_SUCCESS)
+    {
+      std::cerr << "Backend error in EnqueueCopyImageToBuffer 1D : " << GetOpenCLErrorInfo(err) << std::endl;
     }
-    case CL_MEM_OBJECT_IMAGE2D: {
-      const cl::Image2D memory(src_image_pointer.get(), true);
-      err = queue_pointer.enqueueCopyImageToBuffer(
-        memory, dst_memory, src_origin, src_region, dst_offset, nullptr, nullptr);
-      break;
+    return;
+  }
+  if (src_image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE2D)
+  {
+    const cl::Image2D src_memory(src_image_pointer.get(), true);
+    err = queue_pointer.enqueueCopyImageToBuffer(
+      src_memory, dst_memory, src_origin, src_region, dst_offset, nullptr, nullptr);
+    if (err != CL_SUCCESS)
+    {
+      std::cerr << "Backend error in EnqueueCopyImageToBuffer 2D : " << GetOpenCLErrorInfo(err) << std::endl;
     }
-    case CL_MEM_OBJECT_IMAGE3D: {
-      const cl::Image3D memory(src_image_pointer.get(), true);
-      err = queue_pointer.enqueueCopyImageToBuffer(
-        memory, dst_memory, src_origin, src_region, dst_offset, nullptr, nullptr);
-      break;
+    return;
+  }
+  if (src_image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE3D)
+  {
+    const cl::Image3D src_memory(src_image_pointer.get(), true);
+    err = queue_pointer.enqueueCopyImageToBuffer(
+      src_memory, dst_memory, src_origin, src_region, dst_offset, nullptr, nullptr);
+    if (err != CL_SUCCESS)
+    {
+      std::cerr << "Backend error in EnqueueCopyImageToBuffer 3D : " << GetOpenCLErrorInfo(err) << std::endl;
     }
+    return;
   }
   if (err != CL_SUCCESS)
   {
     std::cerr << "Backend error in EnqueueCopyImageToBuffer : " << GetOpenCLErrorInfo(err) << std::endl;
-  }
-  if (block_flag)
-  {
-    WaitQueueToFinish(queue_pointer);
   }
 }
 
@@ -720,26 +739,39 @@ EnqueueReadFromImage(const cl::CommandQueue &      queue_pointer,
                      void *                        host_memory_pointer) -> void
 {
   cl_int err = CL_SUCCESS;
-  switch (image_pointer.getInfo<CL_MEM_TYPE>())
+
+  if (image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE1D)
   {
-    case CL_MEM_OBJECT_IMAGE1D: {
-      const cl::Image1D memory(image_pointer.get(), true);
-      err = queue_pointer.enqueueReadImage(
-        memory, static_cast<cl_bool>(block_flag), origin, region, 0, 0, host_memory_pointer, nullptr, nullptr);
-      break;
+    const cl::Image1D memory(image_pointer.get(), true);
+    err = queue_pointer.enqueueReadImage(
+      memory, static_cast<cl_bool>(block_flag), origin, region, 0, 0, host_memory_pointer, nullptr, nullptr);
+    if (err != CL_SUCCESS)
+    {
+      std::cerr << "Backend error in EnqueueReadFromImage 1D : " << GetOpenCLErrorInfo(err) << std::endl;
     }
-    case CL_MEM_OBJECT_IMAGE2D: {
-      const cl::Image2D memory(image_pointer.get(), true);
-      err = queue_pointer.enqueueReadImage(
-        memory, static_cast<cl_bool>(block_flag), origin, region, 0, 0, host_memory_pointer, nullptr, nullptr);
-      break;
+    return;
+  }
+  if (image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE2D)
+  {
+    const cl::Image2D memory(image_pointer.get(), true);
+    err = queue_pointer.enqueueReadImage(
+      memory, static_cast<cl_bool>(block_flag), origin, region, 0, 0, host_memory_pointer, nullptr, nullptr);
+    if (err != CL_SUCCESS)
+    {
+      std::cerr << "Backend error in EnqueueReadFromImage 2D : " << GetOpenCLErrorInfo(err) << std::endl;
     }
-    case CL_MEM_OBJECT_IMAGE3D: {
-      const cl::Image3D memory(image_pointer.get(), true);
-      err = queue_pointer.enqueueReadImage(
-        memory, static_cast<cl_bool>(block_flag), origin, region, 0, 0, host_memory_pointer, nullptr, nullptr);
-      break;
+    return;
+  }
+  if (image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE3D)
+  {
+    const cl::Image3D memory(image_pointer.get(), true);
+    err = queue_pointer.enqueueReadImage(
+      memory, static_cast<cl_bool>(block_flag), origin, region, 0, 0, host_memory_pointer, nullptr, nullptr);
+    if (err != CL_SUCCESS)
+    {
+      std::cerr << "Backend error in EnqueueReadFromImage 3D : " << GetOpenCLErrorInfo(err) << std::endl;
     }
+    return;
   }
   if (err != CL_SUCCESS)
   {
@@ -756,26 +788,39 @@ EnqueueWriteToImage(const cl::CommandQueue &      queue_pointer,
                     const void *                  host_memory_pointer) -> void
 {
   cl_int err = CL_SUCCESS;
-  switch (image_pointer.getInfo<CL_MEM_TYPE>())
+
+  if (image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE1D)
   {
-    case CL_MEM_OBJECT_IMAGE1D: {
-      const cl::Image1D memory(image_pointer.get(), true);
-      err = queue_pointer.enqueueWriteImage(
-        memory, static_cast<cl_bool>(block_flag), origin, region, 0, 0, host_memory_pointer, nullptr, nullptr);
-      break;
+    const cl::Image1D memory(image_pointer.get(), true);
+    err = queue_pointer.enqueueWriteImage(
+      memory, static_cast<cl_bool>(block_flag), origin, region, 0, 0, host_memory_pointer, nullptr, nullptr);
+    if (err != CL_SUCCESS)
+    {
+      std::cerr << "Backend error in EnqueueWriteToImage 1D : " << GetOpenCLErrorInfo(err) << std::endl;
     }
-    case CL_MEM_OBJECT_IMAGE2D: {
-      const cl::Image2D memory(image_pointer.get(), true);
-      err = queue_pointer.enqueueWriteImage(
-        memory, static_cast<cl_bool>(block_flag), origin, region, 0, 0, host_memory_pointer, nullptr, nullptr);
-      break;
+    return;
+  }
+  if (image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE2D)
+  {
+    const cl::Image2D memory(image_pointer.get(), true);
+    err = queue_pointer.enqueueWriteImage(
+      memory, static_cast<cl_bool>(block_flag), origin, region, 0, 0, host_memory_pointer, nullptr, nullptr);
+    if (err != CL_SUCCESS)
+    {
+      std::cerr << "Backend error in EnqueueWriteToImage 2D : " << GetOpenCLErrorInfo(err) << std::endl;
     }
-    case CL_MEM_OBJECT_IMAGE3D: {
-      const cl::Image3D memory(image_pointer.get(), true);
-      err = queue_pointer.enqueueWriteImage(
-        memory, static_cast<cl_bool>(block_flag), origin, region, 0, 0, host_memory_pointer, nullptr, nullptr);
-      break;
+    return;
+  }
+  if (image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE3D)
+  {
+    const cl::Image3D memory(image_pointer.get(), true);
+    err = queue_pointer.enqueueWriteImage(
+      memory, static_cast<cl_bool>(block_flag), origin, region, 0, 0, host_memory_pointer, nullptr, nullptr);
+    if (err != CL_SUCCESS)
+    {
+      std::cerr << "Backend error in EnqueueWriteToImage 3D : " << GetOpenCLErrorInfo(err) << std::endl;
     }
+    return;
   }
   if (err != CL_SUCCESS)
   {
@@ -793,31 +838,39 @@ EnqueueFillImage(const cl::CommandQueue &      queue_pointer,
                  const NativeType &            pattern) -> void
 {
   cl_int err = CL_SUCCESS;
-  switch (image_pointer.getInfo<CL_MEM_TYPE>())
+  if (image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE1D)
   {
-    case CL_MEM_OBJECT_IMAGE1D: {
-      const cl::Image1D memory(image_pointer.get(), true);
-      err = queue_pointer.enqueueFillImage(memory, pattern, origin, region, nullptr, nullptr);
-      break;
+    const cl::Image1D memory(image_pointer.get(), true);
+    err = queue_pointer.enqueueFillImage(memory, pattern, origin, region, nullptr, nullptr);
+    if (err != CL_SUCCESS)
+    {
+      std::cerr << "Backend error in EnqueueFillImage 1D : " << GetOpenCLErrorInfo(err) << std::endl;
     }
-    case CL_MEM_OBJECT_IMAGE2D: {
-      const cl::Image2D memory(image_pointer.get(), true);
-      err = queue_pointer.enqueueFillImage(memory, pattern, origin, region, nullptr, nullptr);
-      break;
+    return;
+  }
+  if (image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE2D)
+  {
+    const cl::Image2D memory(image_pointer.get(), true);
+    err = queue_pointer.enqueueFillImage(memory, pattern, origin, region, nullptr, nullptr);
+    if (err != CL_SUCCESS)
+    {
+      std::cerr << "Backend error in EnqueueFillImage 2D : " << GetOpenCLErrorInfo(err) << std::endl;
     }
-    case CL_MEM_OBJECT_IMAGE3D: {
-      const cl::Image3D memory(image_pointer.get(), true);
-      err = queue_pointer.enqueueFillImage(memory, pattern, origin, region, nullptr, nullptr);
-      break;
+    return;
+  }
+  if (image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE3D)
+  {
+    const cl::Image3D memory(image_pointer.get(), true);
+    err = queue_pointer.enqueueFillImage(memory, pattern, origin, region, nullptr, nullptr);
+    if (err != CL_SUCCESS)
+    {
+      std::cerr << "Backend error in EnqueueFillImage 3D : " << GetOpenCLErrorInfo(err) << std::endl;
     }
+    return;
   }
   if (err != CL_SUCCESS)
   {
     std::cerr << "Backend error in EnqueueFillImage : " << GetOpenCLErrorInfo(err) << std::endl;
-  }
-  if (block_flag)
-  {
-    WaitQueueToFinish(queue_pointer);
   }
 }
 
@@ -831,34 +884,42 @@ EnqueueCopyImage(const cl::CommandQueue &      queue_pointer,
                  const std::array<size_t, 3> & region) -> void
 {
   cl_int err = CL_SUCCESS;
-  switch (src_image_pointer.getInfo<CL_MEM_TYPE>())
+  if (image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE1D)
   {
-    case CL_MEM_OBJECT_IMAGE1D: {
-      const cl::Image1D memory(src_image_pointer.get(), true);
-      const cl::Image1D dst_memory(dst_image_pointer.get(), true);
-      err = queue_pointer.enqueueCopyImage(memory, dst_memory, src_origin, dst_origin, region, nullptr, nullptr);
-      break;
+    const cl::Image1D memory(src_image_pointer.get(), true);
+    const cl::Image1D dst_memory(dst_image_pointer.get(), true);
+    err = queue_pointer.enqueueCopyImage(memory, dst_memory, src_origin, dst_origin, region, nullptr, nullptr);
+    if (err != CL_SUCCESS)
+    {
+      std::cerr << "Backend error in EnqueueCopyImage 1D : " << GetOpenCLErrorInfo(err) << std::endl;
     }
-    case CL_MEM_OBJECT_IMAGE2D: {
-      const cl::Image2D memory(src_image_pointer.get(), true);
-      const cl::Image2D dst_memory(dst_image_pointer.get(), true);
-      err = queue_pointer.enqueueCopyImage(memory, dst_memory, src_origin, dst_origin, region, nullptr, nullptr);
-      break;
+    return;
+  }
+  if (image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE2D)
+  {
+    const cl::Image2D memory(src_image_pointer.get(), true);
+    const cl::Image2D dst_memory(dst_image_pointer.get(), true);
+    err = queue_pointer.enqueueCopyImage(memory, dst_memory, src_origin, dst_origin, region, nullptr, nullptr);
+    if (err != CL_SUCCESS)
+    {
+      std::cerr << "Backend error in EnqueueCopyImage 2D : " << GetOpenCLErrorInfo(err) << std::endl;
     }
-    case CL_MEM_OBJECT_IMAGE3D: {
-      const cl::Image3D memory(src_image_pointer.get(), true);
-      const cl::Image3D dst_memory(dst_image_pointer.get(), true);
-      err = queue_pointer.enqueueCopyImage(memory, dst_memory, src_origin, dst_origin, region, nullptr, nullptr);
-      break;
+    return;
+  }
+  if (image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE3D)
+  {
+    const cl::Image3D memory(src_image_pointer.get(), true);
+    const cl::Image3D dst_memory(dst_image_pointer.get(), true);
+    err = queue_pointer.enqueueCopyImage(memory, dst_memory, src_origin, dst_origin, region, nullptr, nullptr);
+    if (err != CL_SUCCESS)
+    {
+      std::cerr << "Backend error in EnqueueCopyImage 3D : " << GetOpenCLErrorInfo(err) << std::endl;
     }
+    return;
   }
   if (err != CL_SUCCESS)
   {
     std::cerr << "Backend error in EnqueueCopyImage : " << GetOpenCLErrorInfo(err) << std::endl;
-  }
-  if (block_flag)
-  {
-    WaitQueueToFinish(queue_pointer);
   }
 }
 

--- a/clic/include/core/cleBackend.hpp
+++ b/clic/include/core/cleBackend.hpp
@@ -884,7 +884,7 @@ EnqueueCopyImage(const cl::CommandQueue &      queue_pointer,
                  const std::array<size_t, 3> & region) -> void
 {
   cl_int err = CL_SUCCESS;
-  if (image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE1D)
+  if (src_image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE1D)
   {
     const cl::Image1D memory(src_image_pointer.get(), true);
     const cl::Image1D dst_memory(dst_image_pointer.get(), true);
@@ -895,7 +895,7 @@ EnqueueCopyImage(const cl::CommandQueue &      queue_pointer,
     }
     return;
   }
-  if (image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE2D)
+  if (src_image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE2D)
   {
     const cl::Image2D memory(src_image_pointer.get(), true);
     const cl::Image2D dst_memory(dst_image_pointer.get(), true);
@@ -906,7 +906,7 @@ EnqueueCopyImage(const cl::CommandQueue &      queue_pointer,
     }
     return;
   }
-  if (image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE3D)
+  if (src_image_pointer.getInfo<CL_MEM_TYPE>() == CL_MEM_OBJECT_IMAGE3D)
   {
     const cl::Image3D memory(src_image_pointer.get(), true);
     const cl::Image3D dst_memory(dst_image_pointer.get(), true);

--- a/clic/include/core/cleMemory.hpp
+++ b/clic/include/core/cleMemory.hpp
@@ -38,12 +38,17 @@ WriteBufferObject(const Image & image, const std::vector<type> & array) -> void
   if (image.Ndim() == 1)
   {
     Backend::EnqueueWriteToBuffer(image.GetDevice()->QueuePtr(), image.Get(), true, 0, byte_length, array.data());
+    return;
   }
-  else
-  {
-    Backend::EnqueueWriteToBufferRect(
-      image.GetDevice()->QueuePtr(), image.Get(), true, image.Origin(), image.Origin(), image.Shape(), array.data());
-  }
+  Backend::EnqueueWriteToBufferRect(
+    image.GetDevice()->QueuePtr(), image.Get(), true, image.Origin(), image.Origin(), image.Shape(), array.data());
+
+  //** this may be only interesting if the buffer is very large and if both map and unmap are done
+  //** in the same scope
+  // auto ptr = Backend::EnqueueMapBuffer(image.GetDevice()->QueuePtr(), image.Get(), true, 0, byte_length);
+  // std::memcpy(ptr, array.data(), byte_length);
+  // Backend::EnqueueUnmapMemObject(image.GetDevice()->QueuePtr(), image.Get(), ptr);
+  // return;
 }
 
 template <class type>
@@ -60,24 +65,29 @@ ReadBufferObject(const Image & image, const std::vector<type> & array) -> void
 {
   if (sizeof(type) != image.GetSizeOfElements())
   {
-    throw(std::runtime_error("Error: Buffer and host array are not of the same type."));
+    throw(std::runtime_error("Error: Buffer and host array are not of the same data type."));
   }
   size_t byte_length = array.size() * DataTypeToSizeOf(image.GetDataType());
   if (image.Ndim() == 1)
   {
     Backend::EnqueueReadFromBuffer(
       image.GetDevice()->QueuePtr(), image.Get(), true, 0, byte_length, (void *)(array.data()));
+    return;
   }
-  else
-  {
-    Backend::EnqueueReadFromBufferRect(image.GetDevice()->QueuePtr(),
-                                       image.Get(),
-                                       true,
-                                       image.Origin(),
-                                       image.Origin(),
-                                       image.Shape(),
-                                       (void *)(array.data()));
-  }
+  Backend::EnqueueReadFromBufferRect(image.GetDevice()->QueuePtr(),
+                                     image.Get(),
+                                     true,
+                                     image.Origin(),
+                                     image.Origin(),
+                                     image.Shape(),
+                                     (void *)(array.data()));
+
+  //** this may be only interesting if the buffer is very large and if both map and unmap are done
+  //** in the same scope
+  //  auto ptr = Backend::EnqueueMapBuffer(image.GetDevice()->QueuePtr(), image.Get(), true, 0, byte_length);
+  //  std::memcpy((void *)(array.data()), ptr, byte_length);
+  //  Backend::EnqueueUnmapMemObject(image.GetDevice()->QueuePtr(), image.Get(), ptr);
+  //  return;
 }
 
 template <class type>


### PR DESCRIPTION
aborded here:
- #76 

Add map/unmap buffer and image backend function.
Add push-pull benchmark test

A quick benchmark test shows that:
- classic buffer push pull - 500Mb in 0.32s
- Rect buffer push pull - 500Mb in 0.32s
- M/UM buffer push pull - 500Mb in 0.62s

The functionnality is, at its current state, not interesting as we do a map/unmap at each operation (push, pull).
The speed gain is if we first map, process the data using kernel and so, then unmap when memory is done being used.
Such usage would demand more rewrite work than wanted for now, hence we post-pone this idea