### PR TITLE
Improve custom kernel call

### DIFF
--- a/clic/include/core/cleImage.hpp
+++ b/clic/include/core/cleImage.hpp
@@ -5,6 +5,7 @@
 #include "cleLightObject.hpp"
 #include "cleTypes.hpp"
 
+#include <variant>
 
 namespace cle
 {
@@ -61,6 +62,9 @@ private:
   ShapeArray       origin_{ 0, 0, 0 };
   ChannelType      channels_type_ = INTENSITY;
 };
+
+using ParametersMap = std::map<std::string, std::variant<Image, float, int>>;
+using ConstantsMap = std::map<std::string, std::variant<float, int>>;
 
 } // namespace cle
 

--- a/clic/include/tier1/cleCustomKernel.hpp
+++ b/clic/include/tier1/cleCustomKernel.hpp
@@ -25,11 +25,9 @@ public:
 };
 
 inline auto
-CustomKernel_Call(const std::shared_ptr<cle::Processor> & device,
-                  const std::string &                     filename,
-                  const std::string &                     name) -> void
+CustomKernel_Call(const std::string & filename, const std::string & name) -> void
 {
-  CustomKernel kernel(device, filename, name, 1);
+  // CustomKernel kernel(device, filename, name, 1);
   // for (auto ite = parameters.begin(); ite != parameters.end(); ite++)
   // {
   //   if (std::holds_alternative<cle::Image>(ite->second))

--- a/clic/include/tier1/cleCustomKernel.hpp
+++ b/clic/include/tier1/cleCustomKernel.hpp
@@ -28,9 +28,9 @@ inline auto
 CustomKernel_Call(const std::shared_ptr<cle::Processor> &                             device,
                   const std::string &                                                 file_name,
                   const std::string &                                                 kernel_name,
-                  const size_t &                                                      dx,
-                  const size_t &                                                      dy,
-                  const size_t &                                                      dz,
+                  const size_t &                                                      range_x,
+                  const size_t &                                                      range_y,
+                  const size_t &                                                      range_z,
                   const std::map<std::string, std::variant<cle::Image, float, int>> & parameters) -> void
 {
   CustomKernel kernel(device, file_name, kernel_name, parameters.size());
@@ -49,7 +49,7 @@ CustomKernel_Call(const std::shared_ptr<cle::Processor> &                       
       kernel.AddScalar(ite->first, std::get<int>(ite->second));
     }
   }
-  kernel.SetRange({ dx, dy, dz });
+  kernel.SetRange({ range_x, range_y, range_z });
   kernel.Execute();
 }
 

--- a/clic/include/tier1/cleCustomKernel.hpp
+++ b/clic/include/tier1/cleCustomKernel.hpp
@@ -51,23 +51,35 @@ CustomKernel_Call(const std::shared_ptr<cle::Processor> &                       
   CustomKernel kernel(device, file_name, kernel_name, parameters.size());
   for (auto ite = parameters.begin(); ite != parameters.end(); ite++)
   {
-    std::visit(
-      [&](auto && arg) {
-        using T = std::decay_t<decltype(arg)>;
-        if constexpr (std::is_same_v<T, cle::Image>)
-        {
-          kernel.AddImage(ite->first, arg);
-        }
-        else if constexpr (std::is_same_v<T, float>)
-        {
-          kernel.AddScalar(ite->first, arg);
-        }
-        else if constexpr (std::is_same_v<T, int>)
-        {
-          kernel.AddScalar(ite->first, arg);
-        }
-      },
-      ite->second);
+    // std::visit(
+    //   [&](auto && arg) {
+    //     using T = std::decay_t<decltype(arg)>;
+    //     if constexpr (std::is_same_v<T, cle::Image>)
+    //     {
+    //       kernel.AddImage(ite->first, arg);
+    //     }
+    //     else if constexpr (std::is_same_v<T, float>)
+    //     {
+    //       kernel.AddScalar(ite->first, arg);
+    //     }
+    //     else if constexpr (std::is_same_v<T, int>)
+    //     {
+    //       kernel.AddScalar(ite->first, arg);
+    //     }
+    //   },
+    //   ite->second);
+    if (std::holds_alternative<cle::Image>(ite->second))
+    {
+      kernel.AddImage(ite->first, std::get<cle::Image>(ite->second));
+    }
+    else if (std::holds_alternative<float>(ite->second))
+    {
+      kernel.AddScalar(ite->first, std::get<float>(ite->second));
+    }
+    else if (std::holds_alternative<int>(ite->second))
+    {
+      kernel.AddScalar(ite->first, std::get<int>(ite->second));
+    }
   }
   kernel.SetRange({ range_x, range_y, range_z });
   kernel.Execute();

--- a/clic/include/tier1/cleCustomKernel.hpp
+++ b/clic/include/tier1/cleCustomKernel.hpp
@@ -25,24 +25,28 @@ public:
 };
 
 inline auto
-CustomKernel_Call(const std::shared_ptr<cle::Processor> & device) -> void
+CustomKernel_Call(const std::shared_ptr<cle::Processor> &                             device,
+                  const std::map<std::string, std::variant<cle::Image, float, int>> & parameters) -> void
 {
   // CustomKernel kernel(device, filename, name, 1);
-  // for (auto ite = parameters.begin(); ite != parameters.end(); ite++)
-  // {
-  //   if (std::holds_alternative<cle::Image>(ite->second))
-  //   {
-  //     kernel.AddImage(ite->first, std::get<cle::Image>(ite->second));
-  //   }
-  //   else if (std::holds_alternative<float>(ite->second))
-  //   {
-  //     kernel.AddScalar(ite->first, std::get<float>(ite->second));
-  //   }
-  //   else if (std::holds_alternative<int>(ite->second))
-  //   {
-  //     kernel.AddScalar(ite->first, std::get<int>(ite->second));
-  //   }
-  // }
+  for (auto ite = parameters.begin(); ite != parameters.end(); ite++)
+  {
+    if (std::holds_alternative<cle::Image>(ite->second))
+    {
+      std::cout << ite->first << " : " << std::get<cle::Image>(ite->second) << std::endl;
+      // kernel.AddImage(ite->first, std::get<cle::Image>(ite->second));
+    }
+    else if (std::holds_alternative<float>(ite->second))
+    {
+      std::cout << ite->first << " : " << std::get<float>(ite->second) << std::endl;
+      // kernel.AddScalar(ite->first, std::get<float>(ite->second));
+    }
+    else if (std::holds_alternative<int>(ite->second))
+    {
+      std::cout << ite->first << " : " << std::get<int>(ite->second) << std::endl;
+      // kernel.AddScalar(ite->first, std::get<int>(ite->second));
+    }
+  }
   std::cout << "device = " << device->GetDeviceName() << std::endl;
   // for (auto x : global_range)
   // {

--- a/clic/include/tier1/cleCustomKernel.hpp
+++ b/clic/include/tier1/cleCustomKernel.hpp
@@ -27,9 +27,7 @@ public:
 inline auto
 CustomKernel_Call(const std::shared_ptr<cle::Processor> & device,
                   const std::string &                     filename,
-                  const std::string &                     name,
-                  // const cle::ParametersMap &              parameters,
-                  const std::array<size_t, 3> & global_range = { 1, 1, 1 }) -> void
+                  const std::string &                     name) -> void
 {
   CustomKernel kernel(device, filename, name, 1);
   // for (auto ite = parameters.begin(); ite != parameters.end(); ite++)
@@ -47,13 +45,13 @@ CustomKernel_Call(const std::shared_ptr<cle::Processor> & device,
   //     kernel.AddScalar(ite->first, std::get<int>(ite->second));
   //   }
   // }
-  std::cout << "c++ global_range = ";
-  for (auto x : global_range)
-  {
-    std::cout << x << " ";
-  }
-  std::cout << std::endl;
-  kernel.SetRange(global_range);
+  // std::cout << "c++ global_range = ";
+  // for (auto x : global_range)
+  // {
+  //   std::cout << x << " ";
+  // }
+  // std::cout << std::endl;
+  // kernel.SetRange(global_range);
   // kernel.Execute();
 }
 

--- a/clic/include/tier1/cleCustomKernel.hpp
+++ b/clic/include/tier1/cleCustomKernel.hpp
@@ -27,7 +27,9 @@ public:
 inline auto
 CustomKernel_Call(const std::shared_ptr<cle::Processor> &                             device,
                   const std::string &                                                 kernel_name,
-                  const std::tuple<size_t, size_t, size_t> &                          global_range,
+                  const size_t &                                                      dx,
+                  const size_t &                                                      dy,
+                  const size_t &                                                      dz,
                   const std::map<std::string, std::variant<cle::Image, float, int>> & parameters) -> void
 {
   // CustomKernel kernel(device, filename, name, 1);
@@ -51,9 +53,7 @@ CustomKernel_Call(const std::shared_ptr<cle::Processor> &                       
   }
   std::cout << "kernel = " << kernel_name << std::endl;
   std::cout << "device = " << device->GetDeviceName() << std::endl;
-  std::cout << "global ranges: ";
-  std::apply([&](auto &&... args) { ((std::cout << args << " "), ...); }, global_range);
-  std::cout << std::endl;
+  std::cout << "global ranges: " << dx << "," << dy << "," << dz << std::cout << std::endl;
   // kernel.SetRange(global_range);
   // kernel.Execute();
 }

--- a/clic/include/tier1/cleCustomKernel.hpp
+++ b/clic/include/tier1/cleCustomKernel.hpp
@@ -53,7 +53,7 @@ CustomKernel_Call(const std::shared_ptr<cle::Processor> &                       
   }
   std::cout << "kernel = " << kernel_name << std::endl;
   std::cout << "device = " << device->GetDeviceName() << std::endl;
-  std::cout << "global ranges: " << dx << "," << dy << "," << dz << std::cout << std::endl;
+  std::cout << "global ranges: " << dx << "," << dy << "," << dz << std::endl;
   // kernel.SetRange(global_range);
   // kernel.Execute();
 }

--- a/clic/include/tier1/cleCustomKernel.hpp
+++ b/clic/include/tier1/cleCustomKernel.hpp
@@ -47,6 +47,22 @@ CustomKernel_Call(const std::shared_ptr<cle::Processor> & device,
       kernel.AddScalar(ite->first, std::get<int>(ite->second));
     }
   }
+  std::cout << "c++ global_range = ";
+  for (auto x : global_range)
+  {
+    std::cout << x << " ";
+  }
+  std::cout << std::endl;
+
+  std::reverse(global_range.begin(), global_range.end());
+
+  std::cout << "c++ global_range R = ";
+  for (auto x : global_range)
+  {
+    std::cout << x << " ";
+  }
+  std::cout << std::endl;
+
   kernel.SetRange(global_range);
   kernel.Execute();
 }

--- a/clic/include/tier1/cleCustomKernel.hpp
+++ b/clic/include/tier1/cleCustomKernel.hpp
@@ -27,7 +27,7 @@ public:
 inline auto
 CustomKernel_Call(const std::shared_ptr<cle::Processor> &                             device,
                   const std::string &                                                 kernel_name,
-                  const std::array<size_t, 3> &                                       global_range,
+                  const std::tuple<size_t, size_t, size_t> &                          global_range,
                   const std::map<std::string, std::variant<cle::Image, float, int>> & parameters) -> void
 {
   // CustomKernel kernel(device, filename, name, 1);
@@ -51,11 +51,8 @@ CustomKernel_Call(const std::shared_ptr<cle::Processor> &                       
   }
   std::cout << "kernel = " << kernel_name << std::endl;
   std::cout << "device = " << device->GetDeviceName() << std::endl;
-  std::cout << "global_range = ";
-  for (auto x : global_range)
-  {
-    std::cout << x << " ";
-  }
+  std::cout << "global ranges: ";
+  std::apply([&](auto &&... args) { ((std::cout << args << " "), ...); }, global_range);
   std::cout << std::endl;
   // kernel.SetRange(global_range);
   // kernel.Execute();

--- a/clic/include/tier1/cleCustomKernel.hpp
+++ b/clic/include/tier1/cleCustomKernel.hpp
@@ -27,6 +27,7 @@ public:
 inline auto
 CustomKernel_Call(const std::shared_ptr<cle::Processor> &                             device,
                   const std::string &                                                 kernel_name,
+                  const std::array<size_t, 3> &                                       global_range,
                   const std::map<std::string, std::variant<cle::Image, float, int>> & parameters) -> void
 {
   // CustomKernel kernel(device, filename, name, 1);
@@ -50,11 +51,12 @@ CustomKernel_Call(const std::shared_ptr<cle::Processor> &                       
   }
   std::cout << "kernel = " << kernel_name << std::endl;
   std::cout << "device = " << device->GetDeviceName() << std::endl;
-  // for (auto x : global_range)
-  // {
-  //   std::cout << x << " ";
-  // }
-  // std::cout << std::endl;
+  std::cout << "global_range = ";
+  for (auto x : global_range)
+  {
+    std::cout << x << " ";
+  }
+  std::cout << std::endl;
   // kernel.SetRange(global_range);
   // kernel.Execute();
 }

--- a/clic/include/tier1/cleCustomKernel.hpp
+++ b/clic/include/tier1/cleCustomKernel.hpp
@@ -33,30 +33,30 @@ CustomKernel_Call(const std::shared_ptr<cle::Processor> &                       
                   const size_t &                                                      dz,
                   const std::map<std::string, std::variant<cle::Image, float, int>> & parameters) -> void
 {
-  // CustomKernel kernel(device, filename, name, 1);
+  CustomKernel kernel(device, file_name, kernel_name, parameters.size());
   for (auto ite = parameters.begin(); ite != parameters.end(); ite++)
   {
     if (std::holds_alternative<cle::Image>(ite->second))
     {
       std::cout << ite->first << " : " << std::get<cle::Image>(ite->second) << std::endl;
-      // kernel.AddImage(ite->first, std::get<cle::Image>(ite->second));
+      kernel.AddImage(ite->first, std::get<cle::Image>(ite->second));
     }
     else if (std::holds_alternative<float>(ite->second))
     {
       std::cout << ite->first << " : " << std::get<float>(ite->second) << std::endl;
-      // kernel.AddScalar(ite->first, std::get<float>(ite->second));
+      kernel.AddScalar(ite->first, std::get<float>(ite->second));
     }
     else if (std::holds_alternative<int>(ite->second))
     {
       std::cout << ite->first << " : " << std::get<int>(ite->second) << std::endl;
-      // kernel.AddScalar(ite->first, std::get<int>(ite->second));
+      kernel.AddScalar(ite->first, std::get<int>(ite->second));
     }
   }
   std::cout << "kernel = " << file_name << " -> " << kernel_name << std::endl;
   std::cout << "device = " << device->GetDeviceName() << std::endl;
   std::cout << "global ranges: " << dx << "," << dy << "," << dz << std::endl;
-  // kernel.SetRange(global_range);
-  // kernel.Execute();
+  kernel.SetRange({ dx, dy, dz });
+  kernel.Execute();
 }
 
 } // namespace cle

--- a/clic/include/tier1/cleCustomKernel.hpp
+++ b/clic/include/tier1/cleCustomKernel.hpp
@@ -25,7 +25,7 @@ public:
 };
 
 inline auto
-CustomKernel_Call() -> void
+CustomKernel_Call(const std::shared_ptr<cle::Processor> & device) -> void
 {
   // CustomKernel kernel(device, filename, name, 1);
   // for (auto ite = parameters.begin(); ite != parameters.end(); ite++)
@@ -43,7 +43,7 @@ CustomKernel_Call() -> void
   //     kernel.AddScalar(ite->first, std::get<int>(ite->second));
   //   }
   // }
-  std::cout << "c++ global_range = ";
+  std::cout << "device = " << device->GetDeviceName() << std::endl;
   // for (auto x : global_range)
   // {
   //   std::cout << x << " ";

--- a/clic/include/tier1/cleCustomKernel.hpp
+++ b/clic/include/tier1/cleCustomKernel.hpp
@@ -53,16 +53,6 @@ CustomKernel_Call(const std::shared_ptr<cle::Processor> & device,
     std::cout << x << " ";
   }
   std::cout << std::endl;
-
-  std::reverse(global_range.begin(), global_range.end());
-
-  std::cout << "c++ global_range R = ";
-  for (auto x : global_range)
-  {
-    std::cout << x << " ";
-  }
-  std::cout << std::endl;
-
   kernel.SetRange(global_range);
   kernel.Execute();
 }

--- a/clic/include/tier1/cleCustomKernel.hpp
+++ b/clic/include/tier1/cleCustomKernel.hpp
@@ -25,7 +25,7 @@ public:
 };
 
 inline auto
-CustomKernel_Call(const std::string & filename, const std::string & name) -> void
+CustomKernel_Call() -> void
 {
   // CustomKernel kernel(device, filename, name, 1);
   // for (auto ite = parameters.begin(); ite != parameters.end(); ite++)
@@ -43,7 +43,7 @@ CustomKernel_Call(const std::string & filename, const std::string & name) -> voi
   //     kernel.AddScalar(ite->first, std::get<int>(ite->second));
   //   }
   // }
-  // std::cout << "c++ global_range = ";
+  std::cout << "c++ global_range = ";
   // for (auto x : global_range)
   // {
   //   std::cout << x << " ";

--- a/clic/include/tier1/cleCustomKernel.hpp
+++ b/clic/include/tier1/cleCustomKernel.hpp
@@ -28,25 +28,25 @@ inline auto
 CustomKernel_Call(const std::shared_ptr<cle::Processor> & device,
                   const std::string &                     filename,
                   const std::string &                     name,
-                  const cle::ParametersMap &              parameters,
-                  const std::array<size_t, 3> &           global_range = { 1, 1, 1 }) -> void
+                  // const cle::ParametersMap &              parameters,
+                  const std::array<size_t, 3> & global_range = { 1, 1, 1 }) -> void
 {
-  CustomKernel kernel(device, filename, name, parameters.size());
-  for (auto ite = parameters.begin(); ite != parameters.end(); ite++)
-  {
-    if (std::holds_alternative<cle::Image>(ite->second))
-    {
-      kernel.AddImage(ite->first, std::get<cle::Image>(ite->second));
-    }
-    else if (std::holds_alternative<float>(ite->second))
-    {
-      kernel.AddScalar(ite->first, std::get<float>(ite->second));
-    }
-    else if (std::holds_alternative<int>(ite->second))
-    {
-      kernel.AddScalar(ite->first, std::get<int>(ite->second));
-    }
-  }
+  CustomKernel kernel(device, filename, name, 1);
+  // for (auto ite = parameters.begin(); ite != parameters.end(); ite++)
+  // {
+  //   if (std::holds_alternative<cle::Image>(ite->second))
+  //   {
+  //     kernel.AddImage(ite->first, std::get<cle::Image>(ite->second));
+  //   }
+  //   else if (std::holds_alternative<float>(ite->second))
+  //   {
+  //     kernel.AddScalar(ite->first, std::get<float>(ite->second));
+  //   }
+  //   else if (std::holds_alternative<int>(ite->second))
+  //   {
+  //     kernel.AddScalar(ite->first, std::get<int>(ite->second));
+  //   }
+  // }
   std::cout << "c++ global_range = ";
   for (auto x : global_range)
   {
@@ -54,7 +54,7 @@ CustomKernel_Call(const std::shared_ptr<cle::Processor> & device,
   }
   std::cout << std::endl;
   kernel.SetRange(global_range);
-  kernel.Execute();
+  // kernel.Execute();
 }
 
 } // namespace cle

--- a/clic/include/tier1/cleCustomKernel.hpp
+++ b/clic/include/tier1/cleCustomKernel.hpp
@@ -38,23 +38,17 @@ CustomKernel_Call(const std::shared_ptr<cle::Processor> &                       
   {
     if (std::holds_alternative<cle::Image>(ite->second))
     {
-      std::cout << ite->first << " : " << std::get<cle::Image>(ite->second) << std::endl;
       kernel.AddImage(ite->first, std::get<cle::Image>(ite->second));
     }
     else if (std::holds_alternative<float>(ite->second))
     {
-      std::cout << ite->first << " : " << std::get<float>(ite->second) << std::endl;
       kernel.AddScalar(ite->first, std::get<float>(ite->second));
     }
     else if (std::holds_alternative<int>(ite->second))
     {
-      std::cout << ite->first << " : " << std::get<int>(ite->second) << std::endl;
       kernel.AddScalar(ite->first, std::get<int>(ite->second));
     }
   }
-  std::cout << "kernel = " << file_name << " -> " << kernel_name << std::endl;
-  std::cout << "device = " << device->GetDeviceName() << std::endl;
-  std::cout << "global ranges: " << dx << "," << dy << "," << dz << std::endl;
   kernel.SetRange({ dx, dy, dz });
   kernel.Execute();
 }

--- a/clic/include/tier1/cleCustomKernel.hpp
+++ b/clic/include/tier1/cleCustomKernel.hpp
@@ -33,21 +33,41 @@ CustomKernel_Call(const std::shared_ptr<cle::Processor> &                       
                   const size_t &                                                      range_z,
                   const std::map<std::string, std::variant<cle::Image, float, int>> & parameters) -> void
 {
+
+  // TODO: cleaner but not working with macos 10.13 and earlier
+  // if (std::holds_alternative<cle::Image>(ite->second))
+  // {
+  //   kernel.AddImage(ite->first, std::get<cle::Image>(ite->second));
+  // }
+  // else if (std::holds_alternative<float>(ite->second))
+  // {
+  //   kernel.AddScalar(ite->first, std::get<float>(ite->second));
+  // }
+  // else if (std::holds_alternative<int>(ite->second))
+  // {
+  //   kernel.AddScalar(ite->first, std::get<int>(ite->second));
+  // }
+
   CustomKernel kernel(device, file_name, kernel_name, parameters.size());
   for (auto ite = parameters.begin(); ite != parameters.end(); ite++)
   {
-    if (std::holds_alternative<cle::Image>(ite->second))
-    {
-      kernel.AddImage(ite->first, std::get<cle::Image>(ite->second));
-    }
-    else if (std::holds_alternative<float>(ite->second))
-    {
-      kernel.AddScalar(ite->first, std::get<float>(ite->second));
-    }
-    else if (std::holds_alternative<int>(ite->second))
-    {
-      kernel.AddScalar(ite->first, std::get<int>(ite->second));
-    }
+    std::visit(
+      [&](auto && arg) {
+        using T = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<T, cle::Image>)
+        {
+          kernel.AddImage(ite->first, arg);
+        }
+        else if constexpr (std::is_same_v<T, float>)
+        {
+          kernel.AddScalar(ite->first, arg);
+        }
+        else if constexpr (std::is_same_v<T, int>)
+        {
+          kernel.AddScalar(ite->first, arg);
+        }
+      },
+      ite->second);
   }
   kernel.SetRange({ range_x, range_y, range_z });
   kernel.Execute();

--- a/clic/include/tier1/cleCustomKernel.hpp
+++ b/clic/include/tier1/cleCustomKernel.hpp
@@ -26,6 +26,7 @@ public:
 
 inline auto
 CustomKernel_Call(const std::shared_ptr<cle::Processor> &                             device,
+                  const std::string &                                                 kernel_name,
                   const std::map<std::string, std::variant<cle::Image, float, int>> & parameters) -> void
 {
   // CustomKernel kernel(device, filename, name, 1);
@@ -47,6 +48,7 @@ CustomKernel_Call(const std::shared_ptr<cle::Processor> &                       
       // kernel.AddScalar(ite->first, std::get<int>(ite->second));
     }
   }
+  std::cout << "kernel = " << kernel_name << std::endl;
   std::cout << "device = " << device->GetDeviceName() << std::endl;
   // for (auto x : global_range)
   // {

--- a/clic/include/tier1/cleCustomKernel.hpp
+++ b/clic/include/tier1/cleCustomKernel.hpp
@@ -15,22 +15,39 @@ public:
                         const size_t &           nb_parameters);
 
   auto
-  AddImages(const std::map<std::string, Image> & images) -> void;
+  AddImage(const std::string & tag, const cle::Image & object) -> void;
 
   auto
-  AddScalars(const std::map<std::string, float> & scalars) -> void;
+  AddScalar(const std::string & tag, const float & value) -> void;
+
+  auto
+  AddScalar(const std::string & tag, const int & value) -> void;
 };
 
 inline auto
 CustomKernel_Call(const std::shared_ptr<cle::Processor> & device,
                   const std::string &                     filename,
                   const std::string &                     name,
-                  const std::map<std::string, Image> &    images,
-                  const std::map<std::string, float> &    scalars) -> void
+                  const cle::ParametersMap &              parameters,
+                  const std::array<size_t, 3> &           global_range = { 1, 1, 1 }) -> void
 {
-  CustomKernel kernel(device, filename, name, images.size() + scalars.size());
-  kernel.AddImages(images);
-  kernel.AddScalars(scalars);
+  CustomKernel kernel(device, filename, name, parameters.size());
+  for (auto ite = parameters.begin(); ite != parameters.end(); ite++)
+  {
+    if (std::holds_alternative<cle::Image>(ite->second))
+    {
+      kernel.AddImage(ite->first, std::get<cle::Image>(ite->second));
+    }
+    else if (std::holds_alternative<float>(ite->second))
+    {
+      kernel.AddScalar(ite->first, std::get<float>(ite->second));
+    }
+    else if (std::holds_alternative<int>(ite->second))
+    {
+      kernel.AddScalar(ite->first, std::get<int>(ite->second));
+    }
+  }
+  kernel.SetRange(global_range);
   kernel.Execute();
 }
 

--- a/clic/include/tier1/cleCustomKernel.hpp
+++ b/clic/include/tier1/cleCustomKernel.hpp
@@ -26,6 +26,7 @@ public:
 
 inline auto
 CustomKernel_Call(const std::shared_ptr<cle::Processor> &                             device,
+                  const std::string &                                                 file_name,
                   const std::string &                                                 kernel_name,
                   const size_t &                                                      dx,
                   const size_t &                                                      dy,
@@ -51,7 +52,7 @@ CustomKernel_Call(const std::shared_ptr<cle::Processor> &                       
       // kernel.AddScalar(ite->first, std::get<int>(ite->second));
     }
   }
-  std::cout << "kernel = " << kernel_name << std::endl;
+  std::cout << "kernel = " << file_name << " -> " << kernel_name << std::endl;
   std::cout << "device = " << device->GetDeviceName() << std::endl;
   std::cout << "global ranges: " << dx << "," << dy << "," << dz << std::endl;
   // kernel.SetRange(global_range);

--- a/clic/src/core/cleProcessor.cpp
+++ b/clic/src/core/cleProcessor.cpp
@@ -114,11 +114,11 @@ Processor::SelectDevice(const std::string & name, const std::string & type) -> v
 auto
 Processor::SelectDevice(const int & idx, const std::string & type) -> void
 {
-  auto                      list_of_device = Processor::GetDevices(type);
+  const auto                list_of_device = Processor::GetDevices(type);
   std::optional<cl::Device> selected_device;
   for (const auto & device : list_of_device)
   {
-    if (idx == -1 || idx == &device - &list_of_device[0])
+    if (idx == -1 || idx == static_cast<int>(&device - &list_of_device[0]))
     {
       selected_device = device;
       break;
@@ -126,7 +126,7 @@ Processor::SelectDevice(const int & idx, const std::string & type) -> void
   }
   if (selected_device.has_value())
   {
-    SetDevicePointers(*selected_device); // Use operator*() to access the value, to replace by value()
+    SetDevicePointers(selected_device.value()); // Use operator*() to access the value, to replace by value()
   }
   throw std::runtime_error("Error: Fail to find/allocate device with index '" + std::to_string(idx) + "' of type '" +
                            type + "'");

--- a/clic/src/tier1/cleCustomKernel.cpp
+++ b/clic/src/tier1/cleCustomKernel.cpp
@@ -22,21 +22,22 @@ CustomKernel::CustomKernel(const ProcessorPointer & device,
 }
 
 auto
-CustomKernel::AddImages(const std::map<std::string, Image> & images) -> void
+CustomKernel::AddImage(const std::string & tag, const cle::Image & object) -> void
 {
-  for (auto ite = images.begin(); ite != images.end(); ite++)
-  {
-    this->AddParameter(ite->first, ite->second);
-  }
+  this->AddParameter(tag, object);
 }
 
 auto
-CustomKernel::AddScalars(const std::map<std::string, float> & scalars) -> void
+CustomKernel::AddScalar(const std::string & tag, const float & value) -> void
 {
-  for (auto ite = scalars.begin(); ite != scalars.end(); ite++)
-  {
-    this->AddParameter(ite->first, ite->second);
-  }
+  this->AddParameter(tag, value);
 }
+
+auto
+CustomKernel::AddScalar(const std::string & tag, const int & value) -> void
+{
+  this->AddParameter(tag, value);
+}
+
 
 } // namespace cle

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -520,7 +520,7 @@ add_test(NAME core_buffer_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COM
 add_test(NAME core_image_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND core_image_test)
 add_test(NAME core_kernel_test_buffer WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND core_kernel_test buffer)
 # add_test(NAME core_kernel_test_image WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND core_kernel_test image)
-add_test(NAME custom_kernel_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND custom_kernel_test ${OCL_KERNELS_DIR}/kernels/absolute.cl)
+add_test(NAME custom_kernel_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND custom_kernel_test ${OCL_KERNELS_DIR}/kernels/add_image_and_scalar.cl)
 add_test(NAME absolute_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND absolute_test)
 add_test(NAME add_image_and_scalar_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND add_image_and_scalar_test)
 add_test(NAME add_image_weighted_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND add_image_weighted_test)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,10 +70,10 @@ target_link_libraries(binary_edge_detection_test PRIVATE CLIc::CLIc)
 set_target_properties(binary_edge_detection_test PROPERTIES FOLDER "Tests")
 
 
-add_executable(custom_kernel_test custom_kernel_test.cpp)
-add_dependencies(custom_kernel_test CLIc)
-target_link_libraries(custom_kernel_test PRIVATE CLIc::CLIc)
-set_target_properties(custom_kernel_test PROPERTIES FOLDER "Tests")
+# add_executable(custom_kernel_test custom_kernel_test.cpp)
+# add_dependencies(custom_kernel_test CLIc)
+# target_link_libraries(custom_kernel_test PRIVATE CLIc::CLIc)
+# set_target_properties(custom_kernel_test PROPERTIES FOLDER "Tests")
 
 
 add_executable(binary_subtract_test binary_subtract_test.cpp)
@@ -520,7 +520,7 @@ add_test(NAME core_buffer_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COM
 add_test(NAME core_image_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND core_image_test)
 add_test(NAME core_kernel_test_buffer WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND core_kernel_test buffer)
 # add_test(NAME core_kernel_test_image WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND core_kernel_test image)
-add_test(NAME custom_kernel_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND custom_kernel_test ${OCL_KERNELS_DIR}/kernels/add_image_and_scalar.cl)
+# add_test(NAME custom_kernel_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND custom_kernel_test ${OCL_KERNELS_DIR}/kernels/add_image_and_scalar.cl)
 add_test(NAME absolute_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND absolute_test)
 add_test(NAME add_image_and_scalar_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND add_image_and_scalar_test)
 add_test(NAME add_image_weighted_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND add_image_weighted_test)
@@ -683,7 +683,7 @@ set_tests_properties(absolute_test
     smaller_or_equal_test
     smaller_test
     sobel_test
-    custom_kernel_test
+    # custom_kernel_test
     sum_all_pixels_test
     sum_reduction_x_test
     sum_x_projection_test

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,10 +70,10 @@ target_link_libraries(binary_edge_detection_test PRIVATE CLIc::CLIc)
 set_target_properties(binary_edge_detection_test PROPERTIES FOLDER "Tests")
 
 
-# add_executable(custom_kernel_test custom_kernel_test.cpp)
-# add_dependencies(custom_kernel_test CLIc)
-# target_link_libraries(custom_kernel_test PRIVATE CLIc::CLIc)
-# set_target_properties(custom_kernel_test PROPERTIES FOLDER "Tests")
+add_executable(custom_kernel_test custom_kernel_test.cpp)
+add_dependencies(custom_kernel_test CLIc)
+target_link_libraries(custom_kernel_test PRIVATE CLIc::CLIc)
+set_target_properties(custom_kernel_test PROPERTIES FOLDER "Tests")
 
 
 add_executable(binary_subtract_test binary_subtract_test.cpp)
@@ -520,7 +520,7 @@ add_test(NAME core_buffer_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COM
 add_test(NAME core_image_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND core_image_test)
 add_test(NAME core_kernel_test_buffer WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND core_kernel_test buffer)
 # add_test(NAME core_kernel_test_image WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND core_kernel_test image)
-# add_test(NAME custom_kernel_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND custom_kernel_test ${OCL_KERNELS_DIR}/kernels/add_image_and_scalar.cl)
+add_test(NAME custom_kernel_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND custom_kernel_test ${OCL_KERNELS_DIR}/kernels/add_image_and_scalar.cl)
 add_test(NAME absolute_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND absolute_test)
 add_test(NAME add_image_and_scalar_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND add_image_and_scalar_test)
 add_test(NAME add_image_weighted_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND add_image_weighted_test)
@@ -683,7 +683,7 @@ set_tests_properties(absolute_test
     smaller_or_equal_test
     smaller_test
     sobel_test
-    # custom_kernel_test
+    custom_kernel_test
     sum_all_pixels_test
     sum_reduction_x_test
     sum_x_projection_test

--- a/tests/custom_kernel_test.cpp
+++ b/tests/custom_kernel_test.cpp
@@ -23,7 +23,13 @@ run_test(const std::array<size_t, 3> & shape, const cle::MemoryType & mem_type, 
 
   cle::ParametersMap params = { { "src", gpu_input }, { "dst", gpu_output }, { "scalar", value } };
 
-  cle::CustomKernel_Call(cle.GetDevice(), path, "add_image_and_scalar", params, gpu_output.Shape());
+  cle::CustomKernel_Call(cle.GetDevice(),
+                         path,
+                         "add_image_and_scalar",
+                         gpu_output.Shape()[0],
+                         gpu_output.Shape()[1],
+                         gpu_output.Shape()[2],
+                         params);
 
   auto output = cle.Pull<type>(gpu_output);
 

--- a/tests/custom_kernel_test.cpp
+++ b/tests/custom_kernel_test.cpp
@@ -12,8 +12,8 @@ run_test(const std::array<size_t, 3> & shape, const cle::MemoryType & mem_type, 
   type              value = static_cast<type>(rand() % 10);
   std::vector<type> input(shape[0] * shape[1] * shape[2]);
   std::vector<type> valid(shape[0] * shape[1] * shape[2]);
-  std::fill(input.begin(), input.end(), -value);
-  std::fill(valid.begin(), valid.end(), value);
+  std::fill(input.begin(), input.end(), value);
+  std::fill(valid.begin(), valid.end(), value + value);
 
   cle::Clesperanto cle;
   cle.GetDevice()->WaitForKernelToFinish();
@@ -21,7 +21,9 @@ run_test(const std::array<size_t, 3> & shape, const cle::MemoryType & mem_type, 
   auto gpu_input = cle.Push<type>(input, shape, mem_type);
   auto gpu_output = cle.Create<type>(shape, mem_type);
 
-  cle::CustomKernel_Call(cle.GetDevice(), path, "absolute", { { "src", gpu_input }, { "dst", gpu_output } }, {});
+  cle::ParametersMap params = { { "src", gpu_input }, { "dst", gpu_output }, { "scalar", value } };
+
+  cle::CustomKernel_Call(cle.GetDevice(), path, "add_image_and_scalar", params, gpu_output.Shape());
 
   auto output = cle.Pull<type>(gpu_output);
 


### PR DESCRIPTION
add `std::map<std::string, std::variant<cle::Image, float, int>>` as a futur holder for parameter list
add typedef : ParametersMap
update custom kernel to fit `execute` from the prototype version for compatibility